### PR TITLE
fix: restore LSP auto-start and fix Perspective validation

### DIFF
--- a/lua/ignition/lsp.lua
+++ b/lua/ignition/lsp.lua
@@ -37,6 +37,12 @@ function M.setup(config)
   vim.api.nvim_create_autocmd('FileType', {
     pattern = { 'ignition', 'python' },
     callback = function(args)
+      -- Check if already attached to avoid duplicate clients
+      local clients = vim.lsp.get_clients({ bufnr = args.buf, name = 'ignition_lsp' })
+      if #clients > 0 then
+        return
+      end
+
       -- Get the registered config
       local config = vim.lsp.config.ignition_lsp
       if config then

--- a/lua/ignition/lsp.lua
+++ b/lua/ignition/lsp.lua
@@ -34,7 +34,17 @@ function M.setup(config)
   })
 
   -- Auto-start for matching filetypes in Ignition projects
-  vim.lsp.enable('ignition_lsp')
+  vim.api.nvim_create_autocmd('FileType', {
+    pattern = { 'ignition', 'python' },
+    callback = function(args)
+      -- Get the registered config
+      local config = vim.lsp.config.ignition_lsp
+      if config then
+        vim.lsp.start(config, { bufnr = args.buf })
+      end
+    end,
+    desc = 'Start Ignition LSP for Ignition project files',
+  })
 end
 
 -- Find the Ignition LSP server executable
@@ -82,7 +92,12 @@ function M.start_lsp_for_buffer(bufnr)
     return clients[1].id
   end
 
-  return vim.lsp.start('ignition_lsp', { bufnr = bufnr })
+  local config = vim.lsp.config.ignition_lsp
+  if config then
+    return vim.lsp.start(config, { bufnr = bufnr })
+  end
+
+  return nil
 end
 
 return M


### PR DESCRIPTION
## Summary
- Fixed LSP auto-start by restoring FileType autocmd (regression from modernization commit)
- Fixed Perspective linter to accept both static and bound properties
- Fixed line number enrichment for Perspective diagnostics

## Changes

### ignition-nvim
- Replaced broken `vim.lsp.enable()` with working FileType autocmd
- Fixed `start_lsp_for_buffer()` to pass config table instead of string

### ignition-lint  
- Added line number enrichment to Perspective linter
- Fixed property checks to accept both static (`props.path`) and bound (`propConfig.props.path`) values
- Applies to: icon path, position properties, flex direction

## Fixes
- LSP client now auto-attaches to Python/Ignition files
- Perspective diagnostics show at correct line numbers (not line 0)
- No more false positives for bound properties in Perspective views

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Language Server now automatically starts when opening Ignition or Python files.

* **Bug Fixes**
  * Prevents duplicate language server instances for the same buffer.

* **Chores**
  * Switched to configuration-driven LSP startup via FileType events for more reliable and integrated initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->