### PR TITLE
fix: include java_db in PyPI package

### DIFF
--- a/lsp/pyproject.toml
+++ b/lsp/pyproject.toml
@@ -54,6 +54,7 @@ include = ["ignition_lsp*"]
 [tool.setuptools.package-data]
 ignition_lsp = ["py.typed"]
 "ignition_lsp.api_db" = ["*.json"]
+"ignition_lsp.java_db" = ["*.json"]
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Added java_db JSON files to package-data in pyproject.toml. This enables Java completions in the released PyPI package (141 classes from 26 modules covering java.*, javax.*, and com.inductiveautomation.*).

Previously only api_db was included, causing Java completions to fail with "0 classes loaded" warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Enhanced package distribution configuration to include additional Java database resources, ensuring complete functionality is available in installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->