### PR TITLE
feat: LSP snippets for required params only and pyrightconfig.json generation

### DIFF
--- a/lsp/ignition_lsp/script_symbols.py
+++ b/lsp/ignition_lsp/script_symbols.py
@@ -35,8 +35,12 @@ class ScriptFunction:
         """Generate an LSP snippet with ${1:param} placeholders."""
         if not self.params:
             return f"{self.name}()$0"
+        # Only include required params (those without =... defaults) in snippets
+        required = [p for p in self.params if "=" not in p]
+        if not required:
+            return f"{self.name}()$0"
         parts = []
-        for i, param in enumerate(self.params, 1):
+        for i, param in enumerate(required, 1):
             parts.append(f"${{{i}:{param}}}")
         return f"{self.name}({', '.join(parts)})$0"
 
@@ -167,8 +171,18 @@ def _node_to_str(node: ast.AST) -> str:
 def _extract_function(node: ast.FunctionDef) -> ScriptFunction:
     """Extract a ScriptFunction from an ast.FunctionDef node."""
     # Parameter names (skip self/cls for methods)
-    all_params = [arg.arg for arg in node.args.args]
-    is_method = len(all_params) > 0 and all_params[0] in ("self", "cls")
+    # Mark params with defaults using "= ..." suffix for stub generation
+    all_param_names = [arg.arg for arg in node.args.args]
+    num_defaults = len(node.args.defaults)
+    num_params = len(all_param_names)
+    all_params = []
+    for i, name in enumerate(all_param_names):
+        # defaults are right-aligned: last num_defaults params have defaults
+        if i >= num_params - num_defaults:
+            all_params.append(f"{name}=...")
+        else:
+            all_params.append(name)
+    is_method = len(all_param_names) > 0 and all_param_names[0] in ("self", "cls")
     params = all_params[1:] if is_method else all_params
 
     # Build signature

--- a/lsp/ignition_lsp/stub_generator.py
+++ b/lsp/ignition_lsp/stub_generator.py
@@ -8,6 +8,7 @@ Reuses the SymbolCache already populated during project scanning — stub
 generation is just string formatting on top of already-extracted AST data.
 """
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -73,6 +74,7 @@ def generate_project_stubs(
         return None
 
     _update_gitignore(project_index.root_path)
+    _update_pyrightconfig(project_index.root_path)
 
     logger.info(
         f"Generated {len(written_paths)} stub files in {stubs_dir}"
@@ -201,3 +203,30 @@ def _update_gitignore(root_path: str) -> None:
         gitignore_path.write_text(content, encoding="utf-8")
     else:
         gitignore_path.write_text(f"{entry}\n", encoding="utf-8")
+
+
+def _update_pyrightconfig(root_path: str) -> None:
+    """Create or update pyrightconfig.json so Pyright can find .ignition-stubs/."""
+    config_path = Path(root_path) / "pyrightconfig.json"
+    stubs_entry = f".{STUBS_DIR_NAME.lstrip('.')}"  # ".ignition-stubs"
+
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning(f"Could not parse {config_path}, skipping pyrightconfig update")
+            return
+    else:
+        config = {}
+
+    extra_paths = config.get("extraPaths", [])
+    if stubs_entry not in extra_paths:
+        extra_paths.append(stubs_entry)
+        config["extraPaths"] = extra_paths
+
+    config.setdefault("reportMissingImports", "warning")
+    config.setdefault("reportMissingModuleSource", "none")
+
+    config_path.write_text(
+        json.dumps(config, indent=2) + "\n", encoding="utf-8"
+    )

--- a/lsp/tests/test_completion.py
+++ b/lsp/tests/test_completion.py
@@ -441,7 +441,7 @@ class TestLeafModuleCompletions:
         assert len(items) == 1
         item = items[0]
         assert item.kind == CompletionItemKind.Function
-        assert "def process(data, timeout)" in item.detail
+        assert "def process(data, timeout=...)" in item.detail
 
     def test_partial_filtering(self, tmp_path, symbol_cache):
         path = _write_py(tmp_path, '''\

--- a/lsp/tests/test_script_symbols.py
+++ b/lsp/tests/test_script_symbols.py
@@ -53,7 +53,7 @@ class TestExtractSimpleFunction:
         symbols = extract_symbols(path)
         f = symbols.functions[0]
         assert f.docstring == "Process incoming data with optional timeout."
-        assert f.params == ["data", "timeout"]
+        assert f.params == ["data", "timeout=..."]
 
     def test_function_with_defaults(self, tmp_path):
         path = _write_py(tmp_path, """\
@@ -62,7 +62,7 @@ class TestExtractSimpleFunction:
         """)
         symbols = extract_symbols(path)
         f = symbols.functions[0]
-        assert f.params == ["name", "value", "enabled"]
+        assert f.params == ["name", "value=...", "enabled=..."]
 
     def test_function_with_decorators(self, tmp_path):
         path = _write_py(tmp_path, """\

--- a/lsp/tests/test_stub_generator.py
+++ b/lsp/tests/test_stub_generator.py
@@ -1,5 +1,6 @@
 """Tests for stub_generator.py — .pyi stub generation for project scripts."""
 
+import json
 import os
 import textwrap
 
@@ -283,7 +284,7 @@ class TestStubContent:
         generate_project_stubs(index, cache)
 
         stub = (root / STUBS_DIR_NAME / "project" / "typed.pyi").read_text()
-        assert "def process(data, count) -> bool: ..." in stub
+        assert "def process(data, count=...) -> bool: ..." in stub
 
     def test_class_with_bases(self, tmp_path):
         root, index = _make_project(tmp_path, {
@@ -330,3 +331,75 @@ class TestStubContent:
         assert not (root / STUBS_DIR_NAME / "project" / "broken.pyi").exists()
         # Good module should
         assert (root / STUBS_DIR_NAME / "project" / "good.pyi").exists()
+
+
+# ── Pyrightconfig Tests ─────────────────────────────────────────────
+
+
+class TestPyrightConfig:
+    def test_creates_pyrightconfig_if_missing(self, tmp_path):
+        root, index = _make_project(tmp_path, {
+            "project.utils": "def f(): pass\n",
+        })
+        cache = SymbolCache()
+        generate_project_stubs(index, cache)
+
+        config_path = root / "pyrightconfig.json"
+        assert config_path.exists()
+        config = json.loads(config_path.read_text())
+        assert ".ignition-stubs" in config["extraPaths"]
+        assert config["reportMissingImports"] == "warning"
+        assert config["reportMissingModuleSource"] == "none"
+
+    def test_merges_into_existing_pyrightconfig(self, tmp_path):
+        root, index = _make_project(tmp_path, {
+            "project.utils": "def f(): pass\n",
+        })
+        # Pre-existing config with user settings
+        config_path = root / "pyrightconfig.json"
+        config_path.write_text(json.dumps({
+            "pythonVersion": "3.9",
+            "typeCheckingMode": "basic",
+        }, indent=2))
+
+        cache = SymbolCache()
+        generate_project_stubs(index, cache)
+
+        config = json.loads(config_path.read_text())
+        assert config["pythonVersion"] == "3.9"
+        assert config["typeCheckingMode"] == "basic"
+        assert ".ignition-stubs" in config["extraPaths"]
+        assert config["reportMissingImports"] == "warning"
+        assert config["reportMissingModuleSource"] == "none"
+
+    def test_does_not_duplicate_extraPaths_entry(self, tmp_path):
+        root, index = _make_project(tmp_path, {
+            "project.utils": "def f(): pass\n",
+        })
+        config_path = root / "pyrightconfig.json"
+        config_path.write_text(json.dumps({
+            "extraPaths": [".ignition-stubs"],
+        }, indent=2))
+
+        cache = SymbolCache()
+        generate_project_stubs(index, cache)
+
+        config = json.loads(config_path.read_text())
+        assert config["extraPaths"].count(".ignition-stubs") == 1
+
+    def test_preserves_existing_extraPaths(self, tmp_path):
+        root, index = _make_project(tmp_path, {
+            "project.utils": "def f(): pass\n",
+        })
+        config_path = root / "pyrightconfig.json"
+        config_path.write_text(json.dumps({
+            "extraPaths": ["./vendor", "./typings"],
+        }, indent=2))
+
+        cache = SymbolCache()
+        generate_project_stubs(index, cache)
+
+        config = json.loads(config_path.read_text())
+        assert "./vendor" in config["extraPaths"]
+        assert "./typings" in config["extraPaths"]
+        assert ".ignition-stubs" in config["extraPaths"]


### PR DESCRIPTION
### TL;DR

Enhanced function parameter handling to distinguish between required and optional parameters, and added automatic pyrightconfig.json configuration for better IDE integration.

### What changed?

- Modified function parameter extraction to mark parameters with default values using `=...` suffix
- Updated completion snippets to only include required parameters (those without defaults)
- Added automatic creation and updating of `pyrightconfig.json` to configure Pyright for stub discovery
- The pyrightconfig includes `.ignition-stubs` in `extraPaths` and sets appropriate import reporting levels

### How to test?

1. Create a Python function with both required and optional parameters (e.g., `def process(data, timeout=30):`)
2. Verify that completion snippets only show required parameters as placeholders
3. Generate project stubs and confirm that `pyrightconfig.json` is created/updated with correct settings
4. Check that existing pyrightconfig settings are preserved when merging

### Why make this change?

This improves the developer experience by reducing noise in autocompletion (only showing required parameters) while providing better type checking integration through automatic Pyright configuration. The parameter marking also makes function signatures more informative by clearly indicating which parameters have default values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic IDE configuration management now ensures proper code intelligence support for stubs

* **Improvements**
  * Code completion snippets now display only required parameters, reducing unnecessary placeholders
  * Function signatures now clearly indicate which parameters have default values in completion details and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->