### PR TITLE
feat(plugin): add testing integration to ignition-scada plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "ignition-tools",
+  "owner": {
+    "name": "Whiskey House"
+  },
+  "metadata": {
+    "description": "Development tools for Inductive Automation's Ignition SCADA platform"
+  },
+  "plugins": [
+    {
+      "name": "ignition-scada",
+      "source": "./claude-code-plugin",
+      "description": "Ignition SCADA development — API reference, expression language, auto-linting, test scaffolding, and automated testing for Ignition projects",
+      "version": "0.2.0",
+      "author": {
+        "name": "Whiskey House"
+      },
+      "homepage": "https://github.com/TheThoughtagen/ignition-ide-plugins",
+      "repository": "https://github.com/TheThoughtagen/ignition-ide-plugins",
+      "license": "MIT",
+      "keywords": ["ignition", "scada", "ics", "inductive-automation", "jython", "testing", "playwright"]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ packages/ignition-vscode/node_modules/
 packages/ignition-vscode/out/
 packages/ignition-vscode/*.vsix
 !packages/ignition-vscode/src/lib/
+!claude-code-plugin/scripts/lib/
 
 # Documentation
 doc/tags

--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ignition-scada",
-  "description": "Ignition SCADA development — API reference, expression language, and auto-linting for Ignition projects",
-  "version": "0.1.0",
+  "description": "Ignition SCADA development — API reference, expression language, auto-linting, test scaffolding, and automated testing for Ignition projects",
+  "version": "0.2.0",
   "author": {
     "name": "Whiskey House",
     "url": "https://github.com/whiskeyhouse"
@@ -9,7 +9,7 @@
   "homepage": "https://github.com/whiskeyhouse/ignition-nvim",
   "repository": "https://github.com/whiskeyhouse/ignition-nvim",
   "license": "MIT",
-  "keywords": ["ignition", "scada", "ics", "inductive-automation", "jython", "plc"],
+  "keywords": ["ignition", "scada", "ics", "inductive-automation", "jython", "plc", "testing", "playwright"],
   "skills": "./skills/",
   "hooks": "./hooks/hooks.json"
 }

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -226,7 +226,7 @@ claude-code-plugin/
 
 ## Diagnostic Codes
 
-The hook and lint skill report issues using these codes. See the [ignition-lint docs](https://pypi.org/project/ignition-lint-toolkit/) for full details.
+Common codes reported by the hook and lint skill. See the [ignition-lint docs](https://pypi.org/project/ignition-lint-toolkit/) and the [skills reference](../docs/claude-code-plugin/skills-reference.md) for the full list.
 
 **Script:** `JYTHON_SYNTAX_ERROR`, `JYTHON_PRINT_STATEMENT`, `JYTHON_IMPORT_STAR`, `IGNITION_UNKNOWN_SYSTEM_CALL`, `IGNITION_SYSTEM_OVERRIDE`, `LONG_LINE`, `MISSING_DOCSTRING`
 

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -86,7 +86,7 @@ Both approaches include the same lint hook and the same domain knowledge. The pl
 
 Two commands to go from zero to a full test suite:
 
-```
+```bash
 /ignition-scada:init-testing    # Gateway Jython tests
 /ignition-scada:init-e2e        # Playwright browser tests (Perspective)
 ```
@@ -95,7 +95,7 @@ Two commands to go from zero to a full test suite:
 
 The plugin auto-detects your project — name, gateway, tag providers, parent project inheritance — and scaffolds everything you need:
 
-```
+```text
 ❯ /ignition-scada:init-testing
 
 ⏺ Here's what I found:
@@ -138,7 +138,7 @@ It understands Ignition project inheritance — if your parent project already h
 
 Scaffolds Playwright browser tests with Perspective-aware page objects, then authenticates and runs smoke tests:
 
-```
+```text
 ❯ /ignition-scada:init-e2e
 
 ⏺ Perspective module found. Parent project has e2e/.env — copying
@@ -200,7 +200,7 @@ Both support `--dry-run` to preview and `--force` to overwrite. Use `--skip-scri
 
 ## File Structure
 
-```
+```text
 claude-code-plugin/
   .claude-plugin/
     plugin.json               # Plugin manifest (name, version, entry points)

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -54,16 +54,18 @@ Files outside Ignition projects are ignored. The hook is safe for global install
 
 ### Skills
 
-Six skills are bundled:
+Eight skills are bundled:
 
 | Skill | Invocable? | Purpose |
 |-------|-----------|---------|
-| `ignition-api` | Claude-only | Loaded automatically when Claude writes Ignition scripts. Provides Jython conventions, all `system.*` modules, common patterns, and anti-patterns. |
-| `ignition-expressions` | Claude-only | Loaded automatically when Claude writes expression bindings. All 104 functions with signatures, descriptions, and usage tips. |
-| `ignition-lint` | User + Claude | Run `/ignition-scada:ignition-lint` to lint files or the project. Claude explains diagnostics and applies fixes. |
-| `init-testing` | User + Claude | Run `/ignition-scada:init-testing` to scaffold the Jython test framework, WebDev endpoints, and type stubs. Use `--all` to also scaffold e2e tests. |
-| `init-e2e` | User + Claude | Run `/ignition-scada:init-e2e` to scaffold Playwright browser tests for Perspective views. |
-| `test` | User + Claude | Run `/ignition-scada:test` to run gateway or e2e tests. Routes based on arguments. |
+| `ignition-api` | Claude-only | Jython conventions, all `system.*` modules, Ignition resource structure (`resource.json`), script library rules. |
+| `ignition-expressions` | Claude-only | Expression language syntax and all 104 built-in functions. |
+| `ignition-testing` | Claude-only | Test framework reference — `testing.*` modules, decorators, assertions, WebDev endpoints, discovery conventions. |
+| `ignition-e2e` | Claude-only | Playwright reference — Perspective DOM conventions, PerspectivePage, component wrappers, gateway API helper. |
+| `ignition-lint` | User + Claude | `/ignition-scada:ignition-lint` — lint files or the whole project on demand. |
+| `init-testing` | User + Claude | `/ignition-scada:init-testing` — scaffold Jython test framework + WebDev endpoints + type stubs. |
+| `init-e2e` | User + Claude | `/ignition-scada:init-e2e` — scaffold Playwright browser tests for Perspective views. |
+| `test` | User + Claude | `/ignition-scada:test` — run gateway Jython tests or Playwright browser tests. |
 
 Claude-only skills are never shown in the `/` menu — they're background knowledge that Claude draws on when relevant.
 
@@ -82,57 +84,115 @@ Both approaches include the same lint hook and the same domain knowledge. The pl
 
 ## Quick Start — Testing
 
+Two commands to go from zero to a full test suite:
+
+```
+/ignition-scada:init-testing    # Gateway Jython tests
+/ignition-scada:init-e2e        # Playwright browser tests (Perspective)
+```
+
+### What happens when you run `/ignition-scada:init-testing`
+
+The plugin auto-detects your project — name, gateway, tag providers, parent project inheritance — and scaffolds everything you need:
+
+```
+❯ /ignition-scada:init-testing
+
+⏺ Here's what I found:
+
+  ┌────────────┬──────────────────────────────────────────────┐
+  │  Property  │                    Value                     │
+  ├────────────┼──────────────────────────────────────────────┤
+  │ Project    │ My Site HMI (MySite01)                       │
+  ├────────────┼──────────────────────────────────────────────┤
+  │ Gateway    │ https://localhost:9043 (reachable)            │
+  ├────────────┼──────────────────────────────────────────────┤
+  │ Parent     │ Global (has Jython framework + WebDev)        │
+  ├────────────┼──────────────────────────────────────────────┤
+  │ Tag provs  │ SITE01, default, QSI_UDTs                    │
+  └────────────┴──────────────────────────────────────────────┘
+
+  Inherited from parent (NOT created here):
+  The Jython test framework lives in Global and is inherited
+  automatically. Any __tests__ modules you write will be
+  discovered alongside the parent's tests.
+
+  Created here (project-scoped, NOT inherited):
+  - WebDev endpoints (testing/run, testing/tags)
+  - Type stubs (.ignition-stubs/testing/)
+
+⏺ Which tag provider? → SITE01
+
+⏺ Scaffold complete: 14 created, 0 skipped.
+
+⏺ Gateway discovered 11 test modules:
+  core.mes.changeover.__tests__, core.util.__tests__, ...
+
+  Writing your first test:
+  ignition/script-python/<package>/__tests__/code.py
+```
+
+It understands Ignition project inheritance — if your parent project already has the test framework, it skips duplicating scripts and only creates what each project actually needs (WebDev endpoints are project-scoped in Ignition).
+
+### What happens when you run `/ignition-scada:init-e2e`
+
+Scaffolds Playwright browser tests with Perspective-aware page objects, then authenticates and runs smoke tests:
+
+```
+❯ /ignition-scada:init-e2e
+
+⏺ Perspective module found. Parent project has e2e/.env — copying
+  credentials and updating project name.
+
+⏺ Scaffold done: 13 files created.
+
+⏺ Installing dependencies...
+  npm install ✓
+  playwright install chromium ✓
+
+❯ Yes, run the auth setup and smoke tests
+
+⏺ ✓ authenticate (4.6s)
+  ✓ session loads and docks render (2.8s)
+  ✓ page content renders (2.7s)
+  ✓ navigation exists in DOM (3.9s)
+
+  4 passed, 0 failed (19s total)
+```
+
+### Running tests
+
 ```bash
-# Scaffold the Jython test framework + WebDev endpoints
-/ignition-scada:init-testing
-
-# Also scaffold Playwright e2e tests (requires Perspective module)
-/ignition-scada:init-testing --all
-
-# Run tests
 /ignition-scada:test                    # All gateway Jython tests
 /ignition-scada:test changeover         # Specific module
-/ignition-scada:test ui                 # All Playwright tests
-/ignition-scada:test smoke              # Smoke tests only
+/ignition-scada:test core.mes           # By package prefix
+/ignition-scada:test ui                 # All Playwright browser tests
+/ignition-scada:test ui smoke           # Playwright smoke tests only
 ```
 
-### Deterministic Mode
-
-The scaffolding scripts can be run directly without Claude:
-
-```bash
-# Detect project
-./scripts/detect-project.sh /path/to/project
-
-# Scaffold testing
-./scripts/scaffold-testing.sh \
-  --project-root /path/to/project \
-  --project-name MyProject \
-  --gateway-url https://localhost:9043 \
-  --tag-provider MYP01
-
-# Scaffold e2e
-./scripts/scaffold-e2e.sh \
-  --project-root /path/to/project \
-  --project-name MyProject \
-  --gateway-url https://localhost:9043 \
-  --tag-provider MYP01 \
-  --perspective-project QSI_MyProject
-```
-
-Both scripts support `--dry-run` to preview and `--force` to overwrite existing files.
-
-### What Gets Scaffolded
+### What gets scaffolded
 
 **`/ignition-scada:init-testing`** creates:
-- `ignition/script-python/testing/` — 5 modules (runner, assertions, decorators, helpers, reporter)
-- `com.inductiveautomation.webdev/resources/testing/` — 2 endpoints (run, tags)
+- `ignition/script-python/testing/` — 5 modules (runner, assertions, decorators, helpers, reporter) — *skipped if inherited from parent*
+- `com.inductiveautomation.webdev/resources/testing/` — 2 endpoints (run, tags) — *always created, not inherited*
 - `.ignition-stubs/testing/` — type stubs for IDE completion
 
 **`/ignition-scada:init-e2e`** creates:
-- `e2e/` — Playwright config, auth fixtures, gateway API helper, page objects, component wrappers, smoke tests
+- `e2e/` — Playwright config, auth fixtures, gateway API helper, PerspectivePage page object, component wrappers (Button, Table), smoke tests
 
-### Testing Prerequisites
+### Deterministic mode (no Claude)
+
+The scaffolding scripts can be run directly:
+
+```bash
+./scripts/detect-project.sh /path/to/project
+./scripts/scaffold-testing.sh --project-root /path/to/project --project-name MySite --tag-provider SITE01
+./scripts/scaffold-e2e.sh --project-root /path/to/project --project-name MySite --tag-provider SITE01 --perspective-project MySite01
+```
+
+Both support `--dry-run` to preview and `--force` to overwrite. Use `--skip-scripts` if the parent project has the Jython framework.
+
+### Prerequisites
 
 - **Gateway tests:** A running Ignition gateway (local or Docker)
 - **E2E tests:** Node.js, Chromium (installed automatically by Playwright)
@@ -154,8 +214,10 @@ claude-code-plugin/
     run-tests.sh              # Post-commit gateway test hook
     run-ui-tests.sh           # Post-edit Playwright test hook
   skills/
-    ignition-api/SKILL.md         # system.* API reference (Claude-only)
+    ignition-api/SKILL.md         # system.* API + resource structure (Claude-only)
     ignition-expressions/SKILL.md # Expression language reference (Claude-only)
+    ignition-testing/SKILL.md     # Test framework reference (Claude-only)
+    ignition-e2e/SKILL.md         # Playwright/Perspective reference (Claude-only)
     ignition-lint/SKILL.md        # Manual lint skill (user-invocable)
     init-testing/SKILL.md         # Test framework scaffolding (user-invocable)
     init-e2e/SKILL.md             # E2E test scaffolding (user-invocable)

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -1,6 +1,6 @@
 # Ignition SCADA — Claude Code Plugin
 
-A Claude Code plugin that gives Claude full domain awareness when working on Ignition SCADA projects. Includes auto-linting, the complete `system.*` API reference (14 modules, 239 functions), and the expression language catalog (104 functions).
+A Claude Code plugin that gives Claude full domain awareness when working on Ignition SCADA projects. Includes auto-linting, the complete `system.*` API reference (14 modules, 239 functions), the expression language catalog (104 functions), and automated test scaffolding for both Jython gateway tests and Playwright e2e tests.
 
 ## What It Does
 
@@ -10,6 +10,9 @@ A Claude Code plugin that gives Claude full domain awareness when working on Ign
 | **API reference** | Claude knows every `system.*` function — completions, conventions, anti-patterns — without you having to explain the API. |
 | **Expression language** | Claude understands Ignition's expression syntax (NOT Python) and all 104 built-in functions. |
 | **Manual lint skill** | Run `/ignition-scada:ignition-lint` to lint specific files or the whole project on demand. |
+| **Test scaffolding** | `/ignition-scada:init-testing` scaffolds a Jython test framework (runner, assertions, decorators) + WebDev endpoints + type stubs. `/ignition-scada:init-e2e` adds Playwright browser tests. |
+| **Test runner** | `/ignition-scada:test` runs gateway Jython tests or Playwright e2e tests with smart routing. |
+| **Auto-test hooks** | After `git commit`, runs gateway tests automatically. After editing a `view.json`, runs scoped Playwright tests. |
 
 ## Install
 
@@ -51,13 +54,16 @@ Files outside Ignition projects are ignored. The hook is safe for global install
 
 ### Skills
 
-Three skills are bundled:
+Six skills are bundled:
 
 | Skill | Invocable? | Purpose |
 |-------|-----------|---------|
 | `ignition-api` | Claude-only | Loaded automatically when Claude writes Ignition scripts. Provides Jython conventions, all `system.*` modules, common patterns, and anti-patterns. |
 | `ignition-expressions` | Claude-only | Loaded automatically when Claude writes expression bindings. All 104 functions with signatures, descriptions, and usage tips. |
 | `ignition-lint` | User + Claude | Run `/ignition-scada:ignition-lint` to lint files or the project. Claude explains diagnostics and applies fixes. |
+| `init-testing` | User + Claude | Run `/ignition-scada:init-testing` to scaffold the Jython test framework, WebDev endpoints, and type stubs. Use `--all` to also scaffold e2e tests. |
+| `init-e2e` | User + Claude | Run `/ignition-scada:init-e2e` to scaffold Playwright browser tests for Perspective views. |
+| `test` | User + Claude | Run `/ignition-scada:test` to run gateway or e2e tests. Routes based on arguments. |
 
 Claude-only skills are never shown in the `/` menu — they're background knowledge that Claude draws on when relevant.
 
@@ -74,23 +80,86 @@ This repo offers two ways to give Claude Ignition awareness:
 
 Both approaches include the same lint hook and the same domain knowledge. The plugin packages it as a reusable install; the templates embed it directly.
 
+## Quick Start — Testing
+
+```bash
+# Scaffold the Jython test framework + WebDev endpoints
+/ignition-scada:init-testing
+
+# Also scaffold Playwright e2e tests (requires Perspective module)
+/ignition-scada:init-testing --all
+
+# Run tests
+/ignition-scada:test                    # All gateway Jython tests
+/ignition-scada:test changeover         # Specific module
+/ignition-scada:test ui                 # All Playwright tests
+/ignition-scada:test smoke              # Smoke tests only
+```
+
+### Deterministic Mode
+
+The scaffolding scripts can be run directly without Claude:
+
+```bash
+# Detect project
+./scripts/detect-project.sh /path/to/project
+
+# Scaffold testing
+./scripts/scaffold-testing.sh \
+  --project-root /path/to/project \
+  --project-name MyProject \
+  --gateway-url https://localhost:9043 \
+  --tag-provider MYP01
+
+# Scaffold e2e
+./scripts/scaffold-e2e.sh \
+  --project-root /path/to/project \
+  --project-name MyProject \
+  --gateway-url https://localhost:9043 \
+  --tag-provider MYP01 \
+  --perspective-project QSI_MyProject
+```
+
+Both scripts support `--dry-run` to preview and `--force` to overwrite existing files.
+
+### What Gets Scaffolded
+
+**`/ignition-scada:init-testing`** creates:
+- `ignition/script-python/testing/` — 5 modules (runner, assertions, decorators, helpers, reporter)
+- `com.inductiveautomation.webdev/resources/testing/` — 2 endpoints (run, tags)
+- `.ignition-stubs/testing/` — type stubs for IDE completion
+
+**`/ignition-scada:init-e2e`** creates:
+- `e2e/` — Playwright config, auth fixtures, gateway API helper, page objects, component wrappers, smoke tests
+
+### Testing Prerequisites
+
+- **Gateway tests:** A running Ignition gateway (local or Docker)
+- **E2E tests:** Node.js, Chromium (installed automatically by Playwright)
+- **Both:** `jq` for the detection script (pre-installed on most systems)
+
 ## File Structure
 
 ```
 claude-code-plugin/
   .claude-plugin/
-    plugin.json           # Plugin manifest (name, version, entry points)
+    plugin.json               # Plugin manifest (name, version, entry points)
   hooks/
-    hooks.json            # PostToolUse hook config (Write|Edit matcher)
+    hooks.json                # PostToolUse hooks (lint, gateway tests, UI tests)
   scripts/
-    ignition-lint.sh      # Lint hook script (finds project.json, runs linter)
+    detect-project.sh         # Auto-detect project structure and gateway state
+    scaffold-testing.sh       # Scaffold Jython test framework + WebDev endpoints
+    scaffold-e2e.sh           # Scaffold Playwright e2e test setup
+    ignition-lint.sh          # Lint hook script (finds project.json, runs linter)
+    run-tests.sh              # Post-commit gateway test hook
+    run-ui-tests.sh           # Post-edit Playwright test hook
   skills/
-    ignition-api/
-      SKILL.md            # system.* API reference (Claude-only)
-    ignition-expressions/
-      SKILL.md            # Expression language reference (Claude-only)
-    ignition-lint/
-      SKILL.md            # Manual lint skill (user-invocable)
+    ignition-api/SKILL.md         # system.* API reference (Claude-only)
+    ignition-expressions/SKILL.md # Expression language reference (Claude-only)
+    ignition-lint/SKILL.md        # Manual lint skill (user-invocable)
+    init-testing/SKILL.md         # Test framework scaffolding (user-invocable)
+    init-e2e/SKILL.md             # E2E test scaffolding (user-invocable)
+    test/SKILL.md                 # Test runner (user-invocable)
 ```
 
 ## Diagnostic Codes

--- a/claude-code-plugin/hooks/hooks.json
+++ b/claude-code-plugin/hooks/hooks.json
@@ -8,6 +8,21 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ignition-lint.sh",
             "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-ui-tests.sh",
+            "timeout": 120
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh",
+            "timeout": 30
           }
         ]
       }

--- a/claude-code-plugin/hooks/hooks.json
+++ b/claude-code-plugin/hooks/hooks.json
@@ -22,7 +22,7 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh",
-            "timeout": 30
+            "timeout": 120
           }
         ]
       }

--- a/claude-code-plugin/scripts/detect-project.sh
+++ b/claude-code-plugin/scripts/detect-project.sh
@@ -58,14 +58,26 @@ done
 
 GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
 
-# Detect tag providers
+# Detect tag providers from the tags/ directory on disk.
+# Each .json file or subdirectory in tags/ is a provider.
+# Filter out system providers (System, Gateway) — users want their own.
 TAG_PROVIDERS="[]"
-if [ "$GATEWAY_REACHABLE" = true ]; then
-  TAG_PROVIDERS=$(curl -k -s --connect-timeout 3 "$GATEWAY_URL/system/tag-providers" 2>/dev/null || echo "[]")
-  # Validate it's JSON array
-  if ! echo "$TAG_PROVIDERS" | jq -e 'type == "array"' > /dev/null 2>&1; then
-    TAG_PROVIDERS="[]"
-  fi
+if [ -d "$PROJECT_ROOT/tags" ]; then
+  TAG_PROVIDERS=$(
+    (ls "$PROJECT_ROOT/tags" 2>/dev/null || true) | \
+    sed 's/\.json$//' | \
+    grep -v -E '^(System|Gateway)$' | \
+    jq -R -s 'split("\n") | map(select(length > 0))'
+  )
+fi
+# If this project has no tags/ but parent does, check parent
+if [ "$TAG_PROVIDERS" = "[]" ] && [ -n "$PARENT_ROOT" ] && [ -d "$PARENT_ROOT/tags" ]; then
+  TAG_PROVIDERS=$(
+    (ls "$PARENT_ROOT/tags" 2>/dev/null || true) | \
+    sed 's/\.json$//' | \
+    grep -v -E '^(System|Gateway)$' | \
+    jq -R -s 'split("\n") | map(select(length > 0))'
+  )
 fi
 
 # Check for modules

--- a/claude-code-plugin/scripts/detect-project.sh
+++ b/claude-code-plugin/scripts/detect-project.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# detect-project.sh — Auto-detect Ignition project structure and gateway state.
+# Usage: detect-project.sh [project-directory]
+# Outputs JSON with project metadata, gateway status, and existing test infrastructure.
+
+set -euo pipefail
+
+TARGET="${1:-$PWD}"
+
+# Walk up to find project.json
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$TARGET") || {
+  echo '{"error": "No project.json found walking up from '"$TARGET"'"}' >&2
+  exit 1
+}
+
+PROJECT_NAME=$(basename "$PROJECT_ROOT")
+PROJECT_TITLE=$(jq -r '.title // ""' "$PROJECT_ROOT/project.json" 2>/dev/null || echo "")
+
+# Probe gateway
+GATEWAY_URL=""
+GATEWAY_REACHABLE=false
+
+for url in "https://localhost:9043" "http://localhost:8088"; do
+  if curl -k -s --connect-timeout 3 "$url/StatusPing" > /dev/null 2>&1; then
+    GATEWAY_URL="$url"
+    GATEWAY_REACHABLE=true
+    break
+  fi
+done
+
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+
+# Detect tag providers
+TAG_PROVIDERS="[]"
+if [ "$GATEWAY_REACHABLE" = true ]; then
+  TAG_PROVIDERS=$(curl -k -s --connect-timeout 3 "$GATEWAY_URL/system/tag-providers" 2>/dev/null || echo "[]")
+  # Validate it's JSON array
+  if ! echo "$TAG_PROVIDERS" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    TAG_PROVIDERS="[]"
+  fi
+fi
+
+# Check for modules
+HAS_PERSPECTIVE=false
+HAS_WEBDEV=false
+HAS_SCRIPTING=false
+[ -d "$PROJECT_ROOT/com.inductiveautomation.perspective" ] && HAS_PERSPECTIVE=true
+[ -d "$PROJECT_ROOT/com.inductiveautomation.webdev" ] && HAS_WEBDEV=true
+[ -d "$PROJECT_ROOT/ignition/script-python" ] && HAS_SCRIPTING=true
+
+# Check existing test infrastructure
+HAS_JYTHON_FRAMEWORK=false
+HAS_WEBDEV_ENDPOINTS=false
+HAS_E2E=false
+HAS_STUBS=false
+[ -d "$PROJECT_ROOT/ignition/script-python/testing/runner" ] && HAS_JYTHON_FRAMEWORK=true
+[ -d "$PROJECT_ROOT/com.inductiveautomation.webdev/resources/testing/run" ] && HAS_WEBDEV_ENDPOINTS=true
+[ -f "$PROJECT_ROOT/e2e/package.json" ] && HAS_E2E=true
+[ -d "$PROJECT_ROOT/.ignition-stubs/testing" ] && HAS_STUBS=true
+
+jq -n \
+  --arg project_root "$PROJECT_ROOT" \
+  --arg project_title "$PROJECT_TITLE" \
+  --arg project_name "$PROJECT_NAME" \
+  --arg gateway_url "$GATEWAY_URL" \
+  --argjson gateway_reachable "$GATEWAY_REACHABLE" \
+  --argjson has_perspective "$HAS_PERSPECTIVE" \
+  --argjson has_webdev "$HAS_WEBDEV" \
+  --argjson has_scripting "$HAS_SCRIPTING" \
+  --argjson tag_providers "$TAG_PROVIDERS" \
+  --argjson jython_framework "$HAS_JYTHON_FRAMEWORK" \
+  --argjson webdev_endpoints "$HAS_WEBDEV_ENDPOINTS" \
+  --argjson e2e "$HAS_E2E" \
+  --argjson stubs "$HAS_STUBS" \
+  '{
+    project_root: $project_root,
+    project_title: $project_title,
+    project_name: $project_name,
+    gateway_url: $gateway_url,
+    gateway_reachable: $gateway_reachable,
+    has_perspective: $has_perspective,
+    has_webdev: $has_webdev,
+    has_scripting: $has_scripting,
+    tag_providers: $tag_providers,
+    existing_testing: {
+      jython_framework: $jython_framework,
+      webdev_endpoints: $webdev_endpoints,
+      e2e: $e2e,
+      stubs: $stubs
+    }
+  }'

--- a/claude-code-plugin/scripts/detect-project.sh
+++ b/claude-code-plugin/scripts/detect-project.sh
@@ -28,6 +28,22 @@ PROJECT_ROOT=$(find_project_root "$TARGET") || {
 PROJECT_NAME=$(basename "$PROJECT_ROOT")
 PROJECT_TITLE=$(jq -r '.title // ""' "$PROJECT_ROOT/project.json" 2>/dev/null || echo "")
 
+# Check for parent project (Ignition project inheritance)
+PARENT_NAME=$(jq -r '.parent // ""' "$PROJECT_ROOT/project.json" 2>/dev/null || echo "")
+PARENT_ROOT=""
+PARENT_HAS_JYTHON_FRAMEWORK=false
+PARENT_HAS_WEBDEV_ENDPOINTS=false
+
+if [ -n "$PARENT_NAME" ]; then
+  # Parent projects are typically siblings in the same directory
+  CANDIDATE="$(dirname "$PROJECT_ROOT")/$PARENT_NAME"
+  if [ -f "$CANDIDATE/project.json" ]; then
+    PARENT_ROOT="$CANDIDATE"
+    [ -d "$PARENT_ROOT/ignition/script-python/testing/runner" ] && PARENT_HAS_JYTHON_FRAMEWORK=true
+    [ -d "$PARENT_ROOT/com.inductiveautomation.webdev/resources/testing/run" ] && PARENT_HAS_WEBDEV_ENDPOINTS=true
+  fi
+fi
+
 # Probe gateway
 GATEWAY_URL=""
 GATEWAY_REACHABLE=false
@@ -74,6 +90,10 @@ jq -n \
   --arg project_root "$PROJECT_ROOT" \
   --arg project_title "$PROJECT_TITLE" \
   --arg project_name "$PROJECT_NAME" \
+  --arg parent_name "$PARENT_NAME" \
+  --arg parent_root "$PARENT_ROOT" \
+  --argjson parent_has_jython_framework "$PARENT_HAS_JYTHON_FRAMEWORK" \
+  --argjson parent_has_webdev_endpoints "$PARENT_HAS_WEBDEV_ENDPOINTS" \
   --arg gateway_url "$GATEWAY_URL" \
   --argjson gateway_reachable "$GATEWAY_REACHABLE" \
   --argjson has_perspective "$HAS_PERSPECTIVE" \
@@ -88,6 +108,12 @@ jq -n \
     project_root: $project_root,
     project_title: $project_title,
     project_name: $project_name,
+    parent: (if $parent_name == "" then null else {
+      name: $parent_name,
+      root: (if $parent_root == "" then null else $parent_root end),
+      has_jython_framework: $parent_has_jython_framework,
+      has_webdev_endpoints: $parent_has_webdev_endpoints
+    } end),
     gateway_url: $gateway_url,
     gateway_reachable: $gateway_reachable,
     has_perspective: $has_perspective,

--- a/claude-code-plugin/scripts/detect-project.sh
+++ b/claude-code-plugin/scripts/detect-project.sh
@@ -44,6 +44,14 @@ if [ -n "$PARENT_NAME" ]; then
   fi
 fi
 
+# Check for parent e2e .env (can be reused/copied for child projects)
+PARENT_HAS_E2E_ENV=false
+PARENT_E2E_ENV_PATH=""
+if [ -n "$PARENT_ROOT" ] && [ -f "$PARENT_ROOT/e2e/.env" ]; then
+  PARENT_HAS_E2E_ENV=true
+  PARENT_E2E_ENV_PATH="$PARENT_ROOT/e2e/.env"
+fi
+
 # Probe gateway
 GATEWAY_URL=""
 GATEWAY_REACHABLE=false
@@ -106,6 +114,8 @@ jq -n \
   --arg parent_root "$PARENT_ROOT" \
   --argjson parent_has_jython_framework "$PARENT_HAS_JYTHON_FRAMEWORK" \
   --argjson parent_has_webdev_endpoints "$PARENT_HAS_WEBDEV_ENDPOINTS" \
+  --argjson parent_has_e2e_env "$PARENT_HAS_E2E_ENV" \
+  --arg parent_e2e_env_path "$PARENT_E2E_ENV_PATH" \
   --arg gateway_url "$GATEWAY_URL" \
   --argjson gateway_reachable "$GATEWAY_REACHABLE" \
   --argjson has_perspective "$HAS_PERSPECTIVE" \
@@ -124,7 +134,9 @@ jq -n \
       name: $parent_name,
       root: (if $parent_root == "" then null else $parent_root end),
       has_jython_framework: $parent_has_jython_framework,
-      has_webdev_endpoints: $parent_has_webdev_endpoints
+      has_webdev_endpoints: $parent_has_webdev_endpoints,
+      has_e2e_env: $parent_has_e2e_env,
+      e2e_env_path: (if $parent_e2e_env_path == "" then null else $parent_e2e_env_path end)
     } end),
     gateway_url: $gateway_url,
     gateway_reachable: $gateway_reachable,

--- a/claude-code-plugin/scripts/detect-project.sh
+++ b/claude-code-plugin/scripts/detect-project.sh
@@ -5,23 +5,12 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 TARGET="${1:-$PWD}"
 
-# Walk up to find project.json
-find_project_root() {
-  local dir="$1"
-  while [ "$dir" != "/" ]; do
-    if [ -f "$dir/project.json" ]; then
-      echo "$dir"
-      return 0
-    fi
-    dir=$(dirname "$dir")
-  done
-  return 1
-}
-
 PROJECT_ROOT=$(find_project_root "$TARGET") || {
-  echo '{"error": "No project.json found walking up from '"$TARGET"'"}' >&2
+  jq -n --arg target "$TARGET" '{"error": ("No project.json found walking up from " + $target)}' >&2
   exit 1
 }
 
@@ -69,23 +58,23 @@ GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
 # Detect tag providers from the tags/ directory on disk.
 # Each .json file or subdirectory in tags/ is a provider.
 # Filter out system providers (System, Gateway) — users want their own.
-TAG_PROVIDERS="[]"
-if [ -d "$PROJECT_ROOT/tags" ]; then
-  TAG_PROVIDERS=$(
-    (ls "$PROJECT_ROOT/tags" 2>/dev/null || true) | \
+# Detect tag providers from a tags/ directory
+detect_tag_providers() {
+  local dir="$1"
+  if [ -d "$dir/tags" ]; then
+    (ls "$dir/tags" 2>/dev/null || true) | \
     sed 's/\.json$//' | \
-    grep -v -E '^(System|Gateway)$' | \
+    (grep -v -E '^(System|Gateway)$' || true) | \
     jq -R -s 'split("\n") | map(select(length > 0))'
-  )
-fi
+  else
+    echo "[]"
+  fi
+}
+
+TAG_PROVIDERS=$(detect_tag_providers "$PROJECT_ROOT")
 # If this project has no tags/ but parent does, check parent
-if [ "$TAG_PROVIDERS" = "[]" ] && [ -n "$PARENT_ROOT" ] && [ -d "$PARENT_ROOT/tags" ]; then
-  TAG_PROVIDERS=$(
-    (ls "$PARENT_ROOT/tags" 2>/dev/null || true) | \
-    sed 's/\.json$//' | \
-    grep -v -E '^(System|Gateway)$' | \
-    jq -R -s 'split("\n") | map(select(length > 0))'
-  )
+if [ "$TAG_PROVIDERS" = "[]" ] && [ -n "$PARENT_ROOT" ]; then
+  TAG_PROVIDERS=$(detect_tag_providers "$PARENT_ROOT")
 fi
 
 # Check for modules

--- a/claude-code-plugin/scripts/ignition-lint.sh
+++ b/claude-code-plugin/scripts/ignition-lint.sh
@@ -4,6 +4,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
@@ -11,19 +13,6 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi
-
-# Walk up from the file to find project.json (Ignition project marker)
-find_project_root() {
-  local dir="$1"
-  while [ "$dir" != "/" ]; do
-    if [ -f "$dir/project.json" ]; then
-      echo "$dir"
-      return 0
-    fi
-    dir=$(dirname "$dir")
-  done
-  return 1
-}
 
 PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")") || exit 0
 

--- a/claude-code-plugin/scripts/lib/common.sh
+++ b/claude-code-plugin/scripts/lib/common.sh
@@ -21,14 +21,19 @@ write_file() {
   local content="$2"
   local full_path="$PROJECT_ROOT/$filepath"
 
-  if [[ "$DRY_RUN" = true ]]; then
-    echo "  Would create: $filepath"
+  # Check existence before dry-run so --dry-run accurately reflects real behavior
+  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
+    if [[ "$DRY_RUN" = true ]]; then
+      echo "  Would skip (exists): $filepath"
+    else
+      echo "  Skipped (exists): $filepath"
+    fi
+    SKIPPED=$((SKIPPED + 1))
     return
   fi
 
-  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
-    echo "  Skipped (exists): $filepath"
-    SKIPPED=$((SKIPPED + 1))
+  if [[ "$DRY_RUN" = true ]]; then
+    echo "  Would create: $filepath"
     return
   fi
 

--- a/claude-code-plugin/scripts/lib/common.sh
+++ b/claude-code-plugin/scripts/lib/common.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# common.sh — Shared functions for Ignition Dev Tools plugin scripts.
+# Source this file: source "$(dirname "$0")/lib/common.sh"
+
+# Walk up from a directory to find the nearest project.json (Ignition project marker).
+# Usage: PROJECT_ROOT=$(find_project_root "$PWD") || exit 0
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+# Write a file with existence check, dry-run support, and force overwrite.
+# Requires: PROJECT_ROOT, DRY_RUN, FORCE, CREATED, SKIPPED variables set by caller.
+# Usage: write_file "relative/path/file.ext" "$CONTENT"
+write_file() {
+  local filepath="$1"
+  local content="$2"
+  local full_path="$PROJECT_ROOT/$filepath"
+
+  if [[ "$DRY_RUN" = true ]]; then
+    echo "  Would create: $filepath"
+    return
+  fi
+
+  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
+    echo "  Skipped (exists): $filepath"
+    SKIPPED=$((SKIPPED + 1))
+    return
+  fi
+
+  mkdir -p "$(dirname "$full_path")" || {
+    echo "Error: cannot create directory for $filepath — check permissions on $PROJECT_ROOT" >&2
+    exit 1
+  }
+  printf '%s' "$content" > "$full_path"
+  CREATED=$((CREATED + 1))
+  echo "  Created: $filepath"
+}

--- a/claude-code-plugin/scripts/run-tests.sh
+++ b/claude-code-plugin/scripts/run-tests.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# run-tests.sh — Post-commit gateway test hook
+# Triggers gateway scan, runs Jython tests, reports results.
+# Self-gates: silently exits if not in an Ignition project or test infra missing.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only trigger on git commit
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+if [[ ! "$COMMAND" =~ git\ commit($|\ ) ]]; then
+  exit 0
+fi
+
+# Check commit succeeded
+STDOUT=$(echo "$INPUT" | jq -r '.tool_result.stdout // empty')
+if [[ ! "$STDOUT" =~ create\ mode|file\ changed|files\ changed|insertions|deletions ]] && [[ ! "$STDOUT" =~ \[[a-z]+\ [a-f0-9] ]]; then
+  exit 0
+fi
+
+# Find project root
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$PWD") || exit 0
+PROJECT_NAME=$(basename "$PROJECT_ROOT")
+
+# Check test infrastructure exists
+if [ ! -d "$PROJECT_ROOT/com.inductiveautomation.webdev/resources/testing/run" ]; then
+  exit 0
+fi
+
+# Gateway URL
+GATEWAY_URL="${IGNITION_GATEWAY_URL:-}"
+if [ -z "$GATEWAY_URL" ] && [ -f "$PROJECT_ROOT/e2e/.env" ]; then
+  GATEWAY_URL=$(grep -E '^IGNITION_URL=' "$PROJECT_ROOT/e2e/.env" 2>/dev/null | cut -d= -f2- || true)
+fi
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+
+# Check gateway reachable
+if ! curl -k -s --connect-timeout 3 "$GATEWAY_URL/StatusPing" > /dev/null 2>&1; then
+  exit 0
+fi
+
+# Trigger project scan (optional — requires API token)
+TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
+if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
+  TOKEN=$(cat "$TOKEN_FILE")
+  curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+    "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1 || true
+fi
+
+# Wait for scan propagation (best-effort delay — Ignition has no scan-completion endpoint)
+sleep 3
+
+# Run tests
+ENDPOINT="$GATEWAY_URL/system/webdev/$PROJECT_NAME/testing/run"
+RESULT=$(curl -k -s -X POST "$ENDPOINT" 2>/dev/null) || exit 0
+
+# Parse results
+PASSED=$(echo "$RESULT" | jq -r '.passed // 0')
+FAILED=$(echo "$RESULT" | jq -r '.failed // 0')
+ERRORS=$(echo "$RESULT" | jq -r '.errors // 0')
+SKIPPED=$(echo "$RESULT" | jq -r '.skipped // 0')
+TOTAL=$(echo "$RESULT" | jq -r '.total // 0')
+DURATION=$(echo "$RESULT" | jq -r '.duration_ms // 0')
+
+if [ "$FAILED" -eq 0 ] && [ "$ERRORS" -eq 0 ]; then
+  echo "Tests: $PASSED passed, $SKIPPED skipped ($TOTAL total, ${DURATION}ms)" >&2
+else
+  echo "TESTS FAILED: $PASSED passed, $FAILED failed, $ERRORS errors ($TOTAL total, ${DURATION}ms)" >&2
+  echo "$RESULT" | jq -r '
+    .modules[]?.results[]? |
+    select(.status == "failed" or .status == "error") |
+    "  \(.status | ascii_upcase): \(.name) — \(.message)"
+  ' 2>/dev/null >&2 || true
+fi
+
+exit 0

--- a/claude-code-plugin/scripts/run-tests.sh
+++ b/claude-code-plugin/scripts/run-tests.sh
@@ -46,7 +46,7 @@ fi
 TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
 if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
   TOKEN=$(cat "$TOKEN_FILE")
-  if ! curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+  if ! curl -k -s --max-time 10 -X POST -H "X-Ignition-API-Token: $TOKEN" \
     "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1; then
     echo "Warning: project scan request failed — tests may run against stale state" >&2
   fi
@@ -57,7 +57,7 @@ sleep 3
 
 # Run tests
 ENDPOINT="$GATEWAY_URL/system/webdev/$PROJECT_NAME/testing/run"
-RESULT=$(curl -k -s --fail -X POST "$ENDPOINT" 2>/dev/null) || {
+RESULT=$(curl -k -s --fail --max-time 60 -X POST "$ENDPOINT" 2>/dev/null) || {
   echo "Test endpoint unreachable or returned error: $ENDPOINT" >&2
   exit 1
 }

--- a/claude-code-plugin/scripts/run-tests.sh
+++ b/claude-code-plugin/scripts/run-tests.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 INPUT=$(cat)
 
 # Only trigger on git commit
@@ -13,21 +15,11 @@ if [[ ! "$COMMAND" =~ git\ commit($|\ ) ]]; then
   exit 0
 fi
 
-# Check commit succeeded
-STDOUT=$(echo "$INPUT" | jq -r '.tool_result.stdout // empty')
-if [[ ! "$STDOUT" =~ create\ mode|file\ changed|files\ changed|insertions|deletions ]] && [[ ! "$STDOUT" =~ \[[a-z]+\ [a-f0-9] ]]; then
+# Check commit succeeded (exit code 0 = success)
+EXIT_CODE=$(echo "$INPUT" | jq -r '.tool_result.exit_code // 1')
+if [ "$EXIT_CODE" -ne 0 ]; then
   exit 0
 fi
-
-# Find project root
-find_project_root() {
-  local dir="$1"
-  while [ "$dir" != "/" ]; do
-    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
-    dir=$(dirname "$dir")
-  done
-  return 1
-}
 
 PROJECT_ROOT=$(find_project_root "$PWD") || exit 0
 PROJECT_NAME=$(basename "$PROJECT_ROOT")
@@ -46,6 +38,7 @@ GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
 
 # Check gateway reachable
 if ! curl -k -s --connect-timeout 3 "$GATEWAY_URL/StatusPing" > /dev/null 2>&1; then
+  echo "Ignition gateway not reachable at $GATEWAY_URL — skipping post-commit tests" >&2
   exit 0
 fi
 
@@ -53,8 +46,10 @@ fi
 TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
 if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
   TOKEN=$(cat "$TOKEN_FILE")
-  curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
-    "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1 || true
+  if ! curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+    "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1; then
+    echo "Warning: project scan request failed — tests may run against stale state" >&2
+  fi
 fi
 
 # Wait for scan propagation (best-effort delay — Ignition has no scan-completion endpoint)
@@ -62,18 +57,26 @@ sleep 3
 
 # Run tests
 ENDPOINT="$GATEWAY_URL/system/webdev/$PROJECT_NAME/testing/run"
-RESULT=$(curl -k -s -X POST "$ENDPOINT" 2>/dev/null) || exit 0
+RESULT=$(curl -k -s --fail -X POST "$ENDPOINT" 2>/dev/null) || {
+  echo "Test endpoint unreachable or returned error: $ENDPOINT" >&2
+  exit 1
+}
 
-# Parse results
-PASSED=$(echo "$RESULT" | jq -r '.passed // 0')
-FAILED=$(echo "$RESULT" | jq -r '.failed // 0')
-ERRORS=$(echo "$RESULT" | jq -r '.errors // 0')
-SKIPPED=$(echo "$RESULT" | jq -r '.skipped // 0')
-TOTAL=$(echo "$RESULT" | jq -r '.total // 0')
-DURATION=$(echo "$RESULT" | jq -r '.duration_ms // 0')
+# Validate response structure
+if ! echo "$RESULT" | jq -e '.total' > /dev/null 2>&1; then
+  echo "Unexpected response from test endpoint:" >&2
+  echo "$RESULT" | head -5 >&2
+  exit 1
+fi
+
+# Parse results (single jq call)
+read -r PASSED FAILED ERRORS SKIPPED TOTAL DURATION < <(
+  echo "$RESULT" | jq -r '[.passed // 0, .failed // 0, .errors // 0, .skipped // 0, .total // 0, .duration_ms // 0] | @tsv'
+)
 
 if [ "$FAILED" -eq 0 ] && [ "$ERRORS" -eq 0 ]; then
   echo "Tests: $PASSED passed, $SKIPPED skipped ($TOTAL total, ${DURATION}ms)" >&2
+  exit 0
 else
   echo "TESTS FAILED: $PASSED passed, $FAILED failed, $ERRORS errors ($TOTAL total, ${DURATION}ms)" >&2
   echo "$RESULT" | jq -r '
@@ -81,6 +84,5 @@ else
     select(.status == "failed" or .status == "error") |
     "  \(.status | ascii_upcase): \(.name) — \(.message)"
   ' 2>/dev/null >&2 || true
+  exit 1
 fi
-
-exit 0

--- a/claude-code-plugin/scripts/run-ui-tests.sh
+++ b/claude-code-plugin/scripts/run-ui-tests.sh
@@ -4,29 +4,16 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-# Only trigger on view.json edits
+# Only trigger on Perspective view.json edits
 case "$FILE_PATH" in
-  */view.json) ;;
+  *com.inductiveautomation.perspective/views/*/view.json) ;;
   *) exit 0 ;;
 esac
-
-# Must be a Perspective view
-if [[ "$FILE_PATH" != *"com.inductiveautomation.perspective/views/"* ]]; then
-  exit 0
-fi
-
-# Find project root
-find_project_root() {
-  local dir="$1"
-  while [ "$dir" != "/" ]; do
-    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
-    dir=$(dirname "$dir")
-  done
-  return 1
-}
 
 PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")") || exit 0
 E2E_DIR="$PROJECT_ROOT/e2e"
@@ -35,24 +22,40 @@ E2E_DIR="$PROJECT_ROOT/e2e"
 [ -d "$E2E_DIR/node_modules" ] || exit 0
 [ -f "$E2E_DIR/.auth/user.json" ] || exit 0
 
-# Concurrency guard (portable mkdir lock)
+# Concurrency guard (portable mkdir lock with stale detection)
 LOCK_DIR="$E2E_DIR/.playwright-running.lock"
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  exit 0
+  # Check for stale lock (older than 10 minutes)
+  if [ -d "$LOCK_DIR" ]; then
+    LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCK_DIR" 2>/dev/null || echo 0) ))
+    if [ "$LOCK_AGE" -gt 600 ]; then
+      echo "Removing stale Playwright lock (${LOCK_AGE}s old)" >&2
+      rm -rf "$LOCK_DIR"
+      mkdir "$LOCK_DIR" 2>/dev/null || exit 0
+    else
+      echo "Playwright tests already running — skipping" >&2
+      exit 0
+    fi
+  else
+    exit 0
+  fi
 fi
-trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT
 
 # Extract view area for scoped testing
 VIEW_AREA=$(echo "$FILE_PATH" | sed -n 's|.*views/\([^/]*\)/.*|\1|p')
 VIEW_AREA_LOWER=$(echo "$VIEW_AREA" | tr '[:upper:]' '[:lower:]')
 
-TEST_DIR="$E2E_DIR/tests/$VIEW_AREA_LOWER"
-
 cd "$E2E_DIR"
-if [ -d "$TEST_DIR" ]; then
-  npx playwright test "$TEST_DIR" --reporter=list 2>&1 | tail -5 >&2 || true
+if [ -n "$VIEW_AREA_LOWER" ] && [ -d "$E2E_DIR/tests/$VIEW_AREA_LOWER" ]; then
+  npx playwright test "tests/$VIEW_AREA_LOWER" --reporter=list 2>&1 | tail -20 >&2
+  TEST_EXIT=${PIPESTATUS[0]}
 else
-  npx playwright test tests/smoke/ --reporter=list 2>&1 | tail -5 >&2 || true
+  npx playwright test tests/smoke/ --reporter=list 2>&1 | tail -20 >&2
+  TEST_EXIT=${PIPESTATUS[0]}
 fi
 
-exit 0
+if [ "$TEST_EXIT" -ne 0 ]; then
+  echo "Playwright tests failed for view: ${VIEW_AREA:-unknown}" >&2
+  exit 1
+fi

--- a/claude-code-plugin/scripts/run-ui-tests.sh
+++ b/claude-code-plugin/scripts/run-ui-tests.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# run-ui-tests.sh — Post-edit Playwright hook for Perspective view changes.
+# Self-gates: silently exits if not editing a view.json or e2e not set up.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only trigger on view.json edits
+case "$FILE_PATH" in
+  */view.json) ;;
+  *) exit 0 ;;
+esac
+
+# Must be a Perspective view
+if [[ "$FILE_PATH" != *"com.inductiveautomation.perspective/views/"* ]]; then
+  exit 0
+fi
+
+# Find project root
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")") || exit 0
+E2E_DIR="$PROJECT_ROOT/e2e"
+
+# Silent exit if e2e not set up
+[ -d "$E2E_DIR/node_modules" ] || exit 0
+[ -f "$E2E_DIR/.auth/user.json" ] || exit 0
+
+# Concurrency guard (portable mkdir lock)
+LOCK_DIR="$E2E_DIR/.playwright-running.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+# Extract view area for scoped testing
+VIEW_AREA=$(echo "$FILE_PATH" | sed -n 's|.*views/\([^/]*\)/.*|\1|p')
+VIEW_AREA_LOWER=$(echo "$VIEW_AREA" | tr '[:upper:]' '[:lower:]')
+
+TEST_DIR="$E2E_DIR/tests/$VIEW_AREA_LOWER"
+
+cd "$E2E_DIR"
+if [ -d "$TEST_DIR" ]; then
+  npx playwright test "$TEST_DIR" --reporter=list 2>&1 | tail -5 >&2 || true
+else
+  npx playwright test tests/smoke/ --reporter=list 2>&1 | tail -5 >&2 || true
+fi
+
+exit 0

--- a/claude-code-plugin/scripts/scaffold-e2e.sh
+++ b/claude-code-plugin/scripts/scaffold-e2e.sh
@@ -390,31 +390,10 @@ export async function writeTag(
 }
 
 // ── Tag mirroring (OPC → memory copies for testing without PLC) ──
+// To enable mirrorTags(), implement convert_to_memory_tags() in your gateway
+// script library, then uncomment the mirror block in the testing/tags endpoint.
 
-export interface MirrorResult {
-  success: boolean;
-  dest?: string;
-  error?: string;
-}
-
-/**
- * Mirror an OPC tag subtree to memory tags.
- * The mirror copies the entire folder/UDT structure with current values
- * (or safe defaults for bad-quality tags) into writable memory tags.
- */
-export async function mirrorTags(
-  source: string,
-  dest?: string
-): Promise<MirrorResult> {
-  const body: Record<string, unknown> = { source };
-  if (dest) body.dest = dest;
-  const data = (await post("/testing/tags", { mirror: body })) as {
-    mirror: MirrorResult;
-  };
-  return data.mirror;
-}
-
-/** Delete a mirrored tag tree (cleanup after tests). */
+/** Delete a tag tree (cleanup after tests). */
 export async function deleteMirror(path: string): Promise<boolean> {
   const data = (await post("/testing/tags", { deleteTags: path })) as {
     deleteTags: { success: boolean };
@@ -448,17 +427,6 @@ export async function callScript(
 }
 
 // ── Health checks ──
-
-export interface HealthStatus {
-  cpu?: number;
-  memory?: number;
-  uptime?: number;
-  [key: string]: unknown;
-}
-
-export async function getHealth(): Promise<HealthStatus> {
-  return (await get("/GatewayAPI/getSystemHealth")) as HealthStatus;
-}
 
 /** Quick connectivity check — returns true if gateway responds. */
 export async function isGatewayReachable(): Promise<boolean> {
@@ -714,13 +682,13 @@ SMOKE_TESTS=$(cat <<'TSEOF'
 import { test, expect } from "../../fixtures/perspective";
 
 test.describe("Perspective smoke tests", () => {
-  test("session loads and docks render", async ({ perspective }) => {
+  test("session loads successfully", async ({ perspective }) => {
     await perspective.openPage("/");
     await perspective.waitForSession();
 
-    // Top dock should be visible (most Perspective projects have a header dock)
-    const topDock = perspective.page.locator("[data-component-path^='T']");
-    await expect(topDock.first()).toBeVisible({ timeout: 10_000 });
+    // Verify the Perspective session is active by checking for any rendered component
+    const anyComponent = perspective.page.locator("[data-component]");
+    await expect(anyComponent.first()).toBeVisible({ timeout: 15_000 });
   });
 
   test("page content renders", async ({ perspective }) => {
@@ -735,16 +703,18 @@ test.describe("Perspective smoke tests", () => {
     expect(await components.count()).toBeGreaterThan(0);
   });
 
-  test("navigation exists in DOM", async ({ perspective }) => {
-    await perspective.openPage("/");
-    await perspective.waitForSession();
+  test("no console errors on load", async ({ perspective }) => {
+    const errors: string[] = [];
+    perspective.page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
 
-    // Check for a menu tree navigation component anywhere in the DOM
-    const menuTree = perspective.page.locator(
-      "[data-component='ia.navigation.menutree']"
-    );
-    // Navigation may be in a dock or the page — just verify it exists
-    expect(await menuTree.count()).toBeGreaterThan(0);
+    await perspective.openPage("/");
+    await perspective.waitForPageContent();
+
+    // Filter out known benign errors (e.g., favicon 404)
+    const realErrors = errors.filter((e) => !e.includes("favicon"));
+    expect(realErrors).toEqual([]);
   });
 });
 TSEOF

--- a/claude-code-plugin/scripts/scaffold-e2e.sh
+++ b/claude-code-plugin/scripts/scaffold-e2e.sh
@@ -1,0 +1,788 @@
+#!/usr/bin/env bash
+# scaffold-e2e.sh — Scaffold Playwright E2E tests for Perspective views.
+# Part of the Ignition Dev Tools Claude Code plugin.
+#
+# Creates ~13 files in an e2e/ directory:
+#   1. Configuration       (package.json, tsconfig.json, playwright.config.ts, .env.example, .gitignore)
+#   2. Fixtures            (auth.setup.ts, perspective.ts)
+#   3. Helpers             (gateway-api.ts)
+#   4. Page objects        (PerspectivePage.ts)
+#   5. Components          (PerspectiveComponent.ts, Button.ts, Table.ts)
+#   6. Smoke tests         (perspective-loads.spec.ts)
+#
+# Usage:
+#   scaffold-e2e.sh --project-root /path/to/project --project-name MyProject \
+#     [--gateway-url https://localhost:9043] [--tag-provider default] \
+#     [--perspective-project MyProject] [--force] [--dry-run]
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT="" PROJECT_NAME="" GATEWAY_URL="" TAG_PROVIDER=""
+PERSPECTIVE_PROJECT="" FORCE=false DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-root)          PROJECT_ROOT="$2";          shift 2 ;;
+    --project-name)          PROJECT_NAME="$2";          shift 2 ;;
+    --gateway-url)           GATEWAY_URL="$2";           shift 2 ;;
+    --tag-provider)          TAG_PROVIDER="$2";          shift 2 ;;
+    --perspective-project)   PERSPECTIVE_PROJECT="$2";   shift 2 ;;
+    --force)                 FORCE=true;                 shift ;;
+    --dry-run)               DRY_RUN=true;               shift ;;
+    -h|--help)
+      sed -n '2,18s/^# //p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Validate required args
+[[ -z "$PROJECT_ROOT" ]]  && { echo "Error: --project-root required" >&2; exit 1; }
+[[ -z "$PROJECT_NAME" ]]  && { echo "Error: --project-name required" >&2; exit 1; }
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+TAG_PROVIDER="${TAG_PROVIDER:-default}"
+PERSPECTIVE_PROJECT="${PERSPECTIVE_PROJECT:-$PROJECT_NAME}"
+
+# Verify project root exists
+[[ -d "$PROJECT_ROOT" ]] || { echo "Error: project root does not exist: $PROJECT_ROOT" >&2; exit 1; }
+
+# Derive lowercase name for package.json
+PKG_NAME=$(echo "$PROJECT_NAME" | tr '[:upper:]' '[:lower:]' | tr ' _' '--')
+
+CREATED=0 SKIPPED=0
+
+# ---------------------------------------------------------------------------
+# Helper: write a file with existence check
+# ---------------------------------------------------------------------------
+
+write_file() {
+  local filepath="$1"
+  local content="$2"
+  local full_path="$PROJECT_ROOT/$filepath"
+
+  if [[ "$DRY_RUN" = true ]]; then
+    echo "  Would create: $filepath"
+    return
+  fi
+
+  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
+    echo "  Skipped (exists): $filepath"
+    SKIPPED=$((SKIPPED + 1))
+    return
+  fi
+
+  mkdir -p "$(dirname "$full_path")"
+  printf '%s' "$content" > "$full_path"
+  CREATED=$((CREATED + 1))
+  echo "  Created: $filepath"
+}
+
+echo "Scaffolding E2E test framework for project: $PROJECT_NAME"
+echo "  Project root:          $PROJECT_ROOT"
+echo "  Gateway URL:           $GATEWAY_URL"
+echo "  Tag provider:          $TAG_PROVIDER"
+echo "  Perspective project:   $PERSPECTIVE_PROJECT"
+echo ""
+
+# ===================================================================
+# 1. Configuration files
+# ===================================================================
+
+echo "--- Configuration ---"
+
+# --- package.json ---
+
+PACKAGE_JSON=$(cat <<JSONEOF
+{
+  "name": "${PKG_NAME}-e2e",
+  "private": true,
+  "scripts": {
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed",
+    "test:smoke": "npx playwright test tests/smoke/",
+    "report": "npx playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "dotenv": "^16.4.0"
+  }
+}
+JSONEOF
+)
+write_file "e2e/package.json" "$PACKAGE_JSON"
+
+# --- tsconfig.json ---
+
+TSCONFIG_JSON=$(cat <<'JSONEOF'
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@pages/*": ["pages/*"],
+      "@components/*": ["components/*"],
+      "@fixtures/*": ["fixtures/*"]
+    }
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+JSONEOF
+)
+write_file "e2e/tsconfig.json" "$TSCONFIG_JSON"
+
+# --- playwright.config.ts ---
+
+PLAYWRIGHT_CONFIG=$(cat <<'TSEOF'
+import { defineConfig, devices } from "@playwright/test";
+import * as dotenv from "dotenv";
+import * as path from "path";
+
+dotenv.config({ path: path.resolve(__dirname, ".env") });
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["html", { open: "never" }], ["list"]],
+  timeout: 60_000,
+
+  use: {
+    baseURL: process.env.IGNITION_URL || "https://localhost:9043",
+    ignoreHTTPSErrors: true,
+    actionTimeout: 15_000,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+
+  projects: [
+    {
+      name: "setup",
+      testDir: "./fixtures",
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: path.resolve(__dirname, ".auth/user.json"),
+      },
+      dependencies: ["setup"],
+    },
+  ],
+});
+TSEOF
+)
+write_file "e2e/playwright.config.ts" "$PLAYWRIGHT_CONFIG"
+
+# --- .env.example ---
+
+ENV_EXAMPLE=$(cat <<ENVEOF
+IGNITION_URL=${GATEWAY_URL}
+IGNITION_USER=
+IGNITION_PASSWORD=
+PERSPECTIVE_PROJECT=${PERSPECTIVE_PROJECT}
+TAG_PROVIDER=${TAG_PROVIDER}
+ENVEOF
+)
+write_file "e2e/.env.example" "$ENV_EXAMPLE"
+
+# --- .gitignore ---
+
+GITIGNORE=$(cat <<'GIEOF'
+node_modules/
+test-results/
+playwright-report/
+.auth/
+.env
+dist/
+.playwright-running.lock
+GIEOF
+)
+write_file "e2e/.gitignore" "$GITIGNORE"
+
+
+# ===================================================================
+# 2. Fixtures
+# ===================================================================
+
+echo ""
+echo "--- Fixtures ---"
+
+# --- fixtures/auth.setup.ts ---
+
+AUTH_SETUP=$(cat <<'TSEOF'
+import { test as setup } from "@playwright/test";
+import * as path from "path";
+
+const AUTH_FILE = path.resolve(__dirname, "../.auth/user.json");
+
+setup.setTimeout(60_000);
+
+setup("authenticate", async ({ page }) => {
+  const project =
+    process.env.PERSPECTIVE_PROJECT || "MyProject";
+
+  await page.goto(`/data/perspective/client/${project}`);
+
+  // Wait for either a login form or a live Perspective session.
+  // In guest mode, the session starts directly without login.
+  // After a project scan, Perspective takes up to 30s to reload.
+  // Use polling instead of waitForFunction to avoid actionTimeout cap.
+  let result: string = "timeout";
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    result = await page.evaluate(() => {
+      if (document.querySelector("input.username-field")) return "login";
+      if (document.querySelectorAll("[data-component]").length > 0)
+        return "session";
+      return "waiting";
+    });
+    if (result === "login" || result === "session") break;
+    await page.waitForTimeout(1_000);
+  }
+
+  if (result === "timeout" || result === "waiting") {
+    throw new Error(
+      "Neither login form nor Perspective session appeared within 45s"
+    );
+  }
+
+  if (result === "login") {
+    const user = process.env.IGNITION_USER;
+    const pass = process.env.IGNITION_PASSWORD;
+
+    if (!user || !pass) {
+      throw new Error(
+        "Login form detected but IGNITION_USER/PASSWORD not set in e2e/.env"
+      );
+    }
+
+    await page.locator("input.username-field").fill(user);
+    await page.locator("input.password-field").fill(pass);
+    await page.locator("div.submit-button").click();
+
+    await page.waitForFunction(
+      () => document.querySelectorAll("[data-component]").length > 0,
+      { timeout: 30_000 }
+    );
+  }
+
+  // Session is live — persist auth state for reuse
+  await page.context().storageState({ path: AUTH_FILE });
+});
+TSEOF
+)
+write_file "e2e/fixtures/auth.setup.ts" "$AUTH_SETUP"
+
+# --- fixtures/perspective.ts ---
+
+PERSPECTIVE_FIXTURE=$(cat <<'TSEOF'
+import { test as base } from "@playwright/test";
+import { PerspectivePage } from "../pages/PerspectivePage";
+
+type PerspectiveFixtures = {
+  perspective: PerspectivePage;
+};
+
+export const test = base.extend<PerspectiveFixtures>({
+  perspective: async ({ page }, use) => {
+    const perspective = new PerspectivePage(page);
+    await use(perspective);
+  },
+});
+
+export { expect } from "@playwright/test";
+TSEOF
+)
+write_file "e2e/fixtures/perspective.ts" "$PERSPECTIVE_FIXTURE"
+
+
+# ===================================================================
+# 3. Helpers
+# ===================================================================
+
+echo ""
+echo "--- Helpers ---"
+
+# --- helpers/gateway-api.ts (genericized — WHK-specific code removed) ---
+
+GATEWAY_API=$(cat <<TSEOF
+/**
+ * Gateway API helper — calls WebDev endpoints from Playwright tests.
+ *
+ * Uses the testing/tags endpoint for read/write (test-only),
+ * and GatewayAPI endpoints for health checks and queries.
+ */
+
+// Allow self-signed certs — the local gateway uses a self-signed TLS cert.
+// Playwright's \`request\` fixture handles this via \`ignoreHTTPSErrors: true\`,
+// but raw Node \`fetch\` calls in this module need the env var.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+const BASE =
+  process.env.IGNITION_URL || "https://localhost:9043";
+const WEBDEV = \`\${BASE}/system/webdev/${PROJECT_NAME}\`;
+
+async function post(path: string, body: unknown): Promise<unknown> {
+  const res = await fetch(\`\${WEBDEV}\${path}\`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    // @ts-expect-error -- Node 18+ fetch supports this for self-signed certs
+    dispatcher: undefined,
+  });
+  if (!res.ok) {
+    throw new Error(\`\${path} returned \${res.status}: \${await res.text()}\`);
+  }
+  return res.json();
+}
+
+async function get(path: string): Promise<unknown> {
+  const res = await fetch(\`\${WEBDEV}\${path}\`, {
+    // @ts-expect-error
+    dispatcher: undefined,
+  });
+  if (!res.ok) {
+    throw new Error(\`\${path} returned \${res.status}: \${await res.text()}\`);
+  }
+  return res.json();
+}
+
+// ── Tag operations (via testing/tags endpoint) ──
+
+export interface TagValue {
+  value: unknown;
+  quality: string;
+  good: boolean;
+}
+
+export interface WriteResult {
+  path: string;
+  success: boolean;
+  quality: string;
+}
+
+/** Read tag values from the gateway. */
+export async function readTags(
+  paths: string[]
+): Promise<Record<string, TagValue>> {
+  const data = (await post("/testing/tags", { reads: paths })) as {
+    values: Record<string, TagValue>;
+  };
+  return data.values;
+}
+
+/** Write tag values to the gateway. */
+export async function writeTags(
+  writes: Array<{ path: string; value: unknown }>
+): Promise<WriteResult[]> {
+  const data = (await post("/testing/tags", { writes })) as {
+    results: WriteResult[];
+  };
+  return data.results;
+}
+
+/** Read a single tag and return its value (or null if bad quality). */
+export async function readTag(path: string): Promise<unknown> {
+  const values = await readTags([path]);
+  const tag = values[path];
+  return tag?.good ? tag.value : null;
+}
+
+/** Write a single tag value. */
+export async function writeTag(
+  path: string,
+  value: unknown
+): Promise<boolean> {
+  const results = await writeTags([{ path, value }]);
+  return results[0]?.success ?? false;
+}
+
+// ── Tag mirroring (OPC → memory copies for testing without PLC) ──
+
+export interface MirrorResult {
+  success: boolean;
+  dest?: string;
+  error?: string;
+}
+
+/**
+ * Mirror an OPC tag subtree to memory tags.
+ * The mirror copies the entire folder/UDT structure with current values
+ * (or safe defaults for bad-quality tags) into writable memory tags.
+ */
+export async function mirrorTags(
+  source: string,
+  dest?: string
+): Promise<MirrorResult> {
+  const body: Record<string, unknown> = { source };
+  if (dest) body.dest = dest;
+  const data = (await post("/testing/tags", { mirror: body })) as {
+    mirror: MirrorResult;
+  };
+  return data.mirror;
+}
+
+/** Delete a mirrored tag tree (cleanup after tests). */
+export async function deleteMirror(path: string): Promise<boolean> {
+  const data = (await post("/testing/tags", { deleteTags: path })) as {
+    deleteTags: { success: boolean };
+  };
+  return data.deleteTags?.success ?? false;
+}
+
+// ── Gateway script invocation (call real Jython scripts from tests) ──
+
+export interface ScriptResult {
+  success: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/**
+ * Call a gateway script function by its dotted path.
+ * Executes the real Jython code on the gateway — no mocking.
+ *
+ * @example callScript("my.project.scripts.validate", [arg1, arg2])
+ */
+export async function callScript(
+  path: string,
+  args: unknown[] = [],
+  kwargs: Record<string, unknown> = {}
+): Promise<ScriptResult> {
+  const data = (await post("/testing/tags", {
+    script: { path, args, kwargs },
+  })) as { script: ScriptResult };
+  return data.script;
+}
+
+// ── Health checks ──
+
+export interface HealthStatus {
+  cpu?: number;
+  memory?: number;
+  uptime?: number;
+  [key: string]: unknown;
+}
+
+export async function getHealth(): Promise<HealthStatus> {
+  return (await get("/GatewayAPI/getSystemHealth")) as HealthStatus;
+}
+
+/** Quick connectivity check — returns true if gateway responds. */
+export async function isGatewayReachable(): Promise<boolean> {
+  try {
+    const res = await fetch(\`\${BASE}/StatusPing\`, {
+      signal: AbortSignal.timeout(5_000),
+      // @ts-expect-error
+      dispatcher: undefined,
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+TSEOF
+)
+write_file "e2e/helpers/gateway-api.ts" "$GATEWAY_API"
+
+
+# ===================================================================
+# 4. Page Objects
+# ===================================================================
+
+echo ""
+echo "--- Page Objects ---"
+
+# --- pages/PerspectivePage.ts ---
+
+PERSPECTIVE_PAGE=$(cat <<'TSEOF'
+import { Page, Locator } from "@playwright/test";
+
+/**
+ * Base page object for Perspective views.
+ *
+ * Perspective is a React SPA served over WebSocket. Key DOM facts:
+ * - data-component-path uses positional indices, NOT named paths from view.json
+ * - Prefix convention: L[n]=left dock, T[n]=top dock, C=center (page content)
+ * - $ separates embedded view boundaries, : separates child indices
+ * - Never use page.goto() after the initial session open — it creates a new session
+ */
+export class PerspectivePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  private get project(): string {
+    return process.env.PERSPECTIVE_PROJECT || "MyProject";
+  }
+
+  /** Open a Perspective session at the given page route. Call once per test. */
+  async openPage(pageRoute: string): Promise<void> {
+    const route = pageRoute.startsWith("/") ? pageRoute : `/${pageRoute}`;
+    await this.page.goto(
+      `/data/perspective/client/${this.project}${route}`
+    );
+    await this.waitForPageContent();
+  }
+
+  /** Wait for the center (page) content area to render. */
+  async waitForPageContent(timeout = 30_000): Promise<void> {
+    await this.page
+      .locator("[data-component-path^='C']")
+      .first()
+      .waitFor({ state: "visible", timeout });
+  }
+
+  /** Wait for any Perspective components to load (docks included). */
+  async waitForSession(timeout = 30_000): Promise<void> {
+    await this.page.waitForFunction(
+      () => document.querySelectorAll("[data-component]").length > 3,
+      { timeout }
+    );
+  }
+
+  /** Scope a locator to the page content area (excludes docks). */
+  pageContent(): Locator {
+    return this.page.locator("[data-component-path^='C']").first();
+  }
+
+  /** Find a component by type within the page content area. */
+  componentByType(type: string): Locator {
+    return this.page.locator(
+      `[data-component-path^='C'] [data-component='${type}'], [data-component-path^='C'][data-component='${type}']`
+    );
+  }
+
+  /** Find a label containing specific text in the page content area. */
+  pageLabelWithText(text: string): Locator {
+    return this.page
+      .locator("[data-component-path^='C'] [data-component='ia.display.label']")
+      .filter({ hasText: text });
+  }
+
+  /** Find visible text anywhere in the page content (not docks). */
+  pageText(text: string): Locator {
+    return this.pageContent().getByText(text);
+  }
+
+  /** Dismiss any popup overlays (e.g. startup script modals). */
+  async dismissPopups(): Promise<void> {
+    const overlay = this.page.locator(".popup-overlay .close-button");
+    if (await overlay.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await overlay.click();
+    }
+  }
+
+  /** Get all component paths currently in the DOM (useful for debugging). */
+  async dumpComponentPaths(): Promise<string[]> {
+    return this.page.evaluate(() => {
+      const els = document.querySelectorAll("[data-component-path]");
+      return Array.from(els).map((el) => {
+        const path = el.getAttribute("data-component-path") || "";
+        const comp = el.getAttribute("data-component") || "";
+        return `${path} → ${comp}`;
+      });
+    });
+  }
+}
+TSEOF
+)
+write_file "e2e/pages/PerspectivePage.ts" "$PERSPECTIVE_PAGE"
+
+
+# ===================================================================
+# 5. Components
+# ===================================================================
+
+echo ""
+echo "--- Components ---"
+
+# --- components/PerspectiveComponent.ts ---
+
+PERSPECTIVE_COMPONENT=$(cat <<'TSEOF'
+import { Locator, Page } from "@playwright/test";
+
+/**
+ * Base class for Perspective component wrappers.
+ * Wraps a Locator and adds common operations.
+ */
+export class PerspectiveComponent {
+  readonly locator: Locator;
+  readonly page: Page;
+
+  constructor(locator: Locator, page: Page) {
+    this.locator = locator;
+    this.page = page;
+  }
+
+  async isVisible(timeout = 5_000): Promise<boolean> {
+    return this.locator.isVisible({ timeout }).catch(() => false);
+  }
+
+  async waitForVisible(timeout = 10_000): Promise<void> {
+    await this.locator.waitFor({ state: "visible", timeout });
+  }
+
+  async getText(): Promise<string> {
+    return (await this.locator.textContent()) ?? "";
+  }
+}
+TSEOF
+)
+write_file "e2e/components/PerspectiveComponent.ts" "$PERSPECTIVE_COMPONENT"
+
+# --- components/Button.ts ---
+
+BUTTON_COMPONENT=$(cat <<'TSEOF'
+import { Locator, Page } from "@playwright/test";
+import { PerspectiveComponent } from "./PerspectiveComponent";
+
+/**
+ * Wrapper for ia.input.button components.
+ */
+export class Button extends PerspectiveComponent {
+  constructor(locator: Locator, page: Page) {
+    super(locator, page);
+  }
+
+  async click(): Promise<void> {
+    await this.waitForVisible();
+    await this.locator.click();
+  }
+
+  async isEnabled(): Promise<boolean> {
+    // Perspective disables buttons via an "ia_button--disabled" class
+    const classes = (await this.locator.getAttribute("class")) ?? "";
+    return !classes.includes("disabled");
+  }
+}
+TSEOF
+)
+write_file "e2e/components/Button.ts" "$BUTTON_COMPONENT"
+
+# --- components/Table.ts ---
+
+TABLE_COMPONENT=$(cat <<'TSEOF'
+import { Locator, Page } from "@playwright/test";
+import { PerspectiveComponent } from "./PerspectiveComponent";
+
+/**
+ * Wrapper for ia.display.table components.
+ */
+export class Table extends PerspectiveComponent {
+  constructor(locator: Locator, page: Page) {
+    super(locator, page);
+  }
+
+  /** Wait until at least one data row is rendered. */
+  async waitForData(timeout = 15_000): Promise<void> {
+    await this.locator
+      .locator(".ia_table__body__row")
+      .first()
+      .waitFor({ state: "visible", timeout });
+  }
+
+  async getRowCount(): Promise<number> {
+    return this.locator.locator(".ia_table__body__row").count();
+  }
+
+  async clickRow(index: number): Promise<void> {
+    await this.locator
+      .locator(".ia_table__body__row")
+      .nth(index)
+      .click();
+  }
+
+  async getCellText(row: number, column: number): Promise<string> {
+    const cell = this.locator
+      .locator(".ia_table__body__row")
+      .nth(row)
+      .locator(".ia_table__body__cell")
+      .nth(column);
+    return (await cell.textContent()) ?? "";
+  }
+}
+TSEOF
+)
+write_file "e2e/components/Table.ts" "$TABLE_COMPONENT"
+
+
+# ===================================================================
+# 6. Smoke Tests
+# ===================================================================
+
+echo ""
+echo "--- Smoke Tests ---"
+
+# --- tests/smoke/perspective-loads.spec.ts (generic — no WHK references) ---
+
+SMOKE_TESTS=$(cat <<'TSEOF'
+import { test, expect } from "../../fixtures/perspective";
+
+test.describe("Perspective smoke tests", () => {
+  test("session loads and docks render", async ({ perspective }) => {
+    await perspective.openPage("/");
+    await perspective.waitForSession();
+
+    // Top dock should be visible (most Perspective projects have a header dock)
+    const topDock = perspective.page.locator("[data-component-path^='T']");
+    await expect(topDock.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("page content renders", async ({ perspective }) => {
+    await perspective.openPage("/");
+    await perspective.waitForPageContent();
+
+    // At least one Perspective component should exist in the page content area
+    const components = perspective.page.locator(
+      "[data-component-path^='C'] [data-component]"
+    );
+    await expect(components.first()).toBeVisible({ timeout: 10_000 });
+    expect(await components.count()).toBeGreaterThan(0);
+  });
+
+  test("navigation exists in DOM", async ({ perspective }) => {
+    await perspective.openPage("/");
+    await perspective.waitForSession();
+
+    // Check for a menu tree navigation component anywhere in the DOM
+    const menuTree = perspective.page.locator(
+      "[data-component='ia.navigation.menutree']"
+    );
+    // Navigation may be in a dock or the page — just verify it exists
+    expect(await menuTree.count()).toBeGreaterThan(0);
+  });
+});
+TSEOF
+)
+write_file "e2e/tests/smoke/perspective-loads.spec.ts" "$SMOKE_TESTS"
+
+
+# ===================================================================
+# Summary
+# ===================================================================
+
+echo ""
+if [[ "$DRY_RUN" = true ]]; then
+  echo "Dry run complete. No files were written."
+else
+  echo "Scaffold complete: $CREATED created, $SKIPPED skipped."
+fi

--- a/claude-code-plugin/scripts/scaffold-e2e.sh
+++ b/claude-code-plugin/scripts/scaffold-e2e.sh
@@ -17,6 +17,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -55,32 +57,6 @@ PERSPECTIVE_PROJECT="${PERSPECTIVE_PROJECT:-$PROJECT_NAME}"
 PKG_NAME=$(echo "$PROJECT_NAME" | tr '[:upper:]' '[:lower:]' | tr ' _' '--')
 
 CREATED=0 SKIPPED=0
-
-# ---------------------------------------------------------------------------
-# Helper: write a file with existence check
-# ---------------------------------------------------------------------------
-
-write_file() {
-  local filepath="$1"
-  local content="$2"
-  local full_path="$PROJECT_ROOT/$filepath"
-
-  if [[ "$DRY_RUN" = true ]]; then
-    echo "  Would create: $filepath"
-    return
-  fi
-
-  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
-    echo "  Skipped (exists): $filepath"
-    SKIPPED=$((SKIPPED + 1))
-    return
-  fi
-
-  mkdir -p "$(dirname "$full_path")"
-  printf '%s' "$content" > "$full_path"
-  CREATED=$((CREATED + 1))
-  echo "  Created: $filepath"
-}
 
 echo "Scaffolding E2E test framework for project: $PROJECT_NAME"
 echo "  Project root:          $PROJECT_ROOT"

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -167,6 +167,80 @@ WEBDEV_CONFIG_JSON=$(cat <<'WCEOF'
 WCEOF
 )
 
+# Authenticated WebDev config for endpoints with write operations (tags endpoint).
+# Requires a valid Ignition session. The run endpoint stays unauthenticated since
+# it only executes read-only test functions.
+WEBDEV_AUTH_CONFIG_JSON=$(cat <<'WACEOF'
+{
+  "resource-type": "python-resource",
+  "doGet": {
+    "enabled": true,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPost": {
+    "enabled": true,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPut": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doDelete": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doHead": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doOptions": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doTrace": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPatch": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": true,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  }
+}
+WACEOF
+)
+
 echo "Scaffolding test framework for project: $PROJECT_NAME"
 echo "  Project root:  $PROJECT_ROOT"
 echo "  Gateway URL:   $GATEWAY_URL"
@@ -382,24 +456,30 @@ def _discover_test_modules():
 		list[str]: Dotted module paths (e.g. ["core.mes.changeover.__tests__"])
 	"""
 	# Discover project directories dynamically.
-	# The gateway stores projects at /usr/local/bin/ignition/data/projects/.
-	# We scan all projects that have a script-python directory, so tests in
-	# parent projects (inherited via project inheritance) are also found.
+	# Derive the gateway data directory at runtime from the system tag rather
+	# than hardcoding a platform-specific path (Linux vs macOS vs custom install).
 	project_dirs = []
 
-	gateway_projects_root = File("/usr/local/bin/ignition/data/projects")
-	if gateway_projects_root.exists():
-		for project_dir in (gateway_projects_root.listFiles() or []):
-			if not project_dir.isDirectory():
-				continue
-			script_path = File(project_dir, "ignition/script-python")
-			if script_path.exists():
-				project_dirs.append(script_path.getAbsolutePath())
+	data_dir_qv = system.tag.readBlocking(["[System]Gateway/SystemProperties/DataDirectory"])[0]
+	data_dir = data_dir_qv.value if data_dir_qv.quality.isGood() and data_dir_qv.value else None
+	if data_dir:
+		gateway_projects_root = File(data_dir, "projects")
+		if gateway_projects_root.exists():
+			for project_dir in (gateway_projects_root.listFiles() or []):
+				if not project_dir.isDirectory():
+					continue
+				script_path = File(project_dir, "ignition/script-python")
+				if script_path.exists():
+					project_dirs.append(script_path.getAbsolutePath())
 
-	# Fallback: if no gateway path found, try the configured project name
+	# Fallback: if runtime detection failed, try common default paths
 	if not project_dirs:
-		fallback = "/usr/local/bin/ignition/data/projects/" + PROJECT_NAME + "/ignition/script-python"
-		project_dirs.append(fallback)
+		import os
+		for base in ["/usr/local/bin/ignition/data", "C:/Program Files/Inductive Automation/Ignition/data"]:
+			fallback = os.path.join(base, "projects", PROJECT_NAME, "ignition/script-python")
+			if File(fallback).exists():
+				project_dirs.append(fallback)
+				break
 
 	modules = []
 	seen = set()
@@ -1377,21 +1457,18 @@ def doPost(request, session):
 	# your project's script library.  The function should browse the source OPC
 	# tag tree and recreate it under dest with valueSource="memory".
 	# If you don't need mirror functionality, you can safely remove this block.
-	if 'mirror' in data:
-		mirrorCfg = data['mirror']
-		source = mirrorCfg['source']
-		dest = mirrorCfg.get('dest', source + '_MEM')
-		try:
-			# TODO: Replace with your project's convert_to_memory_tags function.
-			# Example: your_project.tools.conversions.convert_to_memory_tags(source, dest)
-			raise NotImplementedError(
-				"Mirror requires a convert_to_memory_tags(source, dest) function. "
-				"Implement one in your script library and update this endpoint."
-			)
-			response['mirror'] = {'success': True, 'dest': dest}
-		except Exception:
-			import traceback
-			response['mirror'] = {'success': False, 'error': traceback.format_exc()}
+	# Mirror tags — copies OPC/device tags to writable memory tags for testing.
+	# Uncomment and implement when your project has a convert_to_memory_tags function.
+	# if 'mirror' in data:
+	# 	mirrorCfg = data['mirror']
+	# 	source = mirrorCfg['source']
+	# 	dest = mirrorCfg.get('dest', source + '_MEM')
+	# 	try:
+	# 		your_project.tools.conversions.convert_to_memory_tags(source, dest)
+	# 		response['mirror'] = {'success': True, 'dest': dest}
+	# 	except Exception:
+	# 		import traceback
+	# 		response['mirror'] = {'success': False, 'error': traceback.format_exc()}
 
 	# Handle deleteTags — remove a tag tree (for cleanup after mirror)
 	if 'deleteTags' in data:
@@ -1481,8 +1558,16 @@ def doPost(request, session):
 		collisionPolicy = importCfg.get('collisionPolicy', 'o')
 		try:
 			import os
-			projectRoot = '/usr/local/bin/ignition/data/projects/PLACEHOLDER_PROJECT_NAME'
-			fullPath = os.path.join(projectRoot, filePath)
+			projectRoot = system.util.getProjectName()
+			projectRoot = os.path.join(
+				system.tag.readBlocking(["[System]Gateway/SystemProperties/DataDirectory"])[0].value or "/usr/local/bin/ignition/data",
+				"projects", projectRoot
+			)
+			fullPath = os.path.normpath(os.path.join(projectRoot, filePath))
+			# Prevent path traversal outside the project directory
+			if not fullPath.startswith(projectRoot + os.sep):
+				response['importTags'] = {'success': False, 'error': 'Invalid filePath: path traversal detected'}
+				return {'json': response}
 			with open(fullPath, 'r') as f:
 				tagJson = f.read()
 			tagObj = system.util.jsonDecode(tagJson)
@@ -1561,7 +1646,7 @@ write_file "com.inductiveautomation.webdev/resources/testing/tags/doPost.py" "$T
 
 # --- tags/config.json ---
 
-write_file "com.inductiveautomation.webdev/resources/testing/tags/config.json" "$WEBDEV_CONFIG_JSON"
+write_file "com.inductiveautomation.webdev/resources/testing/tags/config.json" "$WEBDEV_AUTH_CONFIG_JSON"
 
 # --- tags/resource.json ---
 

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -377,23 +377,33 @@ def _discover_test_modules():
 	Looks for both __tests__ (lowercase, new convention) and __TESTS__
 	(uppercase, legacy convention) directories containing code.py.
 
+	Dynamically discovers all project script-python directories by scanning
+	the gateway's projects folder. This means tests are found in both the
+	current project and any parent/sibling projects — matching how Ignition's
+	project inheritance makes scripts available at runtime.
+
 	Returns:
 		list[str]: Dotted module paths (e.g. ["core.mes.changeover.__tests__"])
 	"""
-	# Ignition project script library root on the gateway filesystem.
-	# The default gateway install path is /usr/local/bin/ignition.
-	# Adjust if your gateway is installed elsewhere.
-	project_dirs = [
-		"/usr/local/bin/ignition/data/projects/" + PROJECT_NAME + "/ignition/script-python",
-	]
+	# Discover project directories dynamically.
+	# The gateway stores projects at /usr/local/bin/ignition/data/projects/.
+	# We scan all projects that have a script-python directory, so tests in
+	# parent projects (inherited via project inheritance) are also found.
+	project_dirs = []
 
-	# NOTE: To test discovery locally (outside the gateway), uncomment the
-	# following lines and set the path to your local project checkout:
-	#
-	# local_path = "/path/to/your/local/projects/" + PROJECT_NAME + "/ignition/script-python"
-	# local_file = File(local_path)
-	# if local_file.exists():
-	#     project_dirs.append(local_path)
+	gateway_projects_root = File("/usr/local/bin/ignition/data/projects")
+	if gateway_projects_root.exists():
+		for project_dir in (gateway_projects_root.listFiles() or []):
+			if not project_dir.isDirectory():
+				continue
+			script_path = File(project_dir, "ignition/script-python")
+			if script_path.exists():
+				project_dirs.append(script_path.getAbsolutePath())
+
+	# Fallback: if no gateway path found, try the configured project name
+	if not project_dirs:
+		fallback = "/usr/local/bin/ignition/data/projects/" + PROJECT_NAME + "/ignition/script-python"
+		project_dirs.append(fallback)
 
 	modules = []
 	seen = set()

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 
 PROJECT_ROOT="" PROJECT_NAME="" GATEWAY_URL="" TAG_PROVIDER=""
-FORCE=false DRY_RUN=false
+FORCE=false DRY_RUN=false SKIP_SCRIPTS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -29,6 +29,7 @@ while [[ $# -gt 0 ]]; do
     --tag-provider)  TAG_PROVIDER="$2";  shift 2 ;;
     --force)         FORCE=true;         shift ;;
     --dry-run)       DRY_RUN=true;       shift ;;
+    --skip-scripts)  SKIP_SCRIPTS=true;  shift ;;
     -h|--help)
       sed -n '2,14s/^# //p' "$0"
       exit 0
@@ -183,6 +184,9 @@ echo ""
 # 1. Jython Test Framework — ignition/script-python/testing/
 # ===================================================================
 
+if [[ "$SKIP_SCRIPTS" = true ]]; then
+  echo "--- Jython Test Framework (skipped — inherited from parent project) ---"
+else
 echo "--- Jython Test Framework ---"
 
 # --- runner/code.py (genericized) ---
@@ -1069,6 +1073,8 @@ write_file "ignition/script-python/testing/reporter/resource.json" "$RESOURCE_JS
 
 
 # ===================================================================
+fi  # end SKIP_SCRIPTS guard
+
 # 2. WebDev Test Endpoints — com.inductiveautomation.webdev/resources/testing/
 # ===================================================================
 

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -14,6 +14,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/lib/common.sh"
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -50,32 +52,6 @@ TAG_PROVIDER="${TAG_PROVIDER:-default}"
 CREATED=0 SKIPPED=0
 
 # ---------------------------------------------------------------------------
-# Helper: write a file with existence check
-# ---------------------------------------------------------------------------
-
-write_file() {
-  local filepath="$1"
-  local content="$2"
-  local full_path="$PROJECT_ROOT/$filepath"
-
-  if [[ "$DRY_RUN" = true ]]; then
-    echo "  Would create: $filepath"
-    return
-  fi
-
-  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
-    echo "  Skipped (exists): $filepath"
-    SKIPPED=$((SKIPPED + 1))
-    return
-  fi
-
-  mkdir -p "$(dirname "$full_path")"
-  printf '%s' "$content" > "$full_path"
-  CREATED=$((CREATED + 1))
-  echo "  Created: $filepath"
-}
-
-# ---------------------------------------------------------------------------
 # Shared resource.json (identical for all 5 script modules)
 # ---------------------------------------------------------------------------
 
@@ -91,12 +67,29 @@ RESOURCE_JSON=$(cat <<'RJEOF'
   "attributes": {
     "lastModification": {
       "actor": "external",
-      "timestamp": "2026-02-20T00:00:00Z"
-    },
-    "hintScope": 2
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
   }
 }
 RJEOF
+)
+
+# Package node resource.json (no code.py — this is a namespace package)
+PACKAGE_RESOURCE_JSON=$(cat <<'PRJEOF'
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": [],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-02-20T00:00:00Z"
+    }
+  }
+}
+PRJEOF
 )
 
 # ---------------------------------------------------------------------------
@@ -188,6 +181,9 @@ if [[ "$SKIP_SCRIPTS" = true ]]; then
   echo "--- Jython Test Framework (skipped — inherited from parent project) ---"
 else
 echo "--- Jython Test Framework ---"
+
+# Package node for testing/ (required by Ignition — without it, child modules are invisible)
+write_file "ignition/script-python/testing/resource.json" "$PACKAGE_RESOURCE_JSON"
 
 # --- runner/code.py (genericized) ---
 
@@ -879,7 +875,7 @@ def write_dataset_tag(tag_path, columns, types, rows):
 			"rowCount": ds.getRowCount(),
 			"error": None if success else str(results[0]),
 		}
-	except:
+	except Exception:
 		import traceback
 		return {
 			"success": False,
@@ -1178,7 +1174,7 @@ def doPost(request, session):
 				package = body_data.get("package", package)
 				fmt = body_data.get("format", fmt)
 		except Exception:
-			pass
+			pass  # Fall through to query string params if body is not valid JSON
 
 	try:
 		if module:
@@ -1211,6 +1207,7 @@ def doPost(request, session):
 
 		# Default JSON
 		status = 200 if results["failed"] == 0 and results["errors"] == 0 else 207
+		request['servletResponse'].setStatus(status)
 		return {"json": results}
 
 	except Exception as e:
@@ -1286,20 +1283,19 @@ TAGS_DOGET=$(cat <<'PYEOF'
 def doGet(request, session):
 	params = request.get('params', {})
 
-	# Simulator CSV download
-	simulatorCsv = params.get('simulatorCsv', None)
-	if simulatorCsv is not None:
-		csv_qv = system.tag.readBlocking(['[PLACEHOLDER_TAG_PROVIDER]WH/Systems/Simulation/DeviceCSV'])[0]
-		if csv_qv.quality.isGood() and csv_qv.value:
-			# Write CSV directly to servlet response for proper Content-Type
-			response = request['servletResponse']
-			response.setContentType('text/csv')
-			response.setHeader('Content-Disposition', 'attachment; filename="PLACEHOLDER_PROJECT_NAME_Sim_program.csv"')
-			writer = response.getWriter()
-			writer.print(csv_qv.value)
-			writer.flush()
-			return
-		return {'json': {'error': 'No CSV generated. Run controller.enable(mode="device") first.'}}
+	# Simulator CSV download (customize the tag path for your project)
+	# simulatorCsv = params.get('simulatorCsv', None)
+	# if simulatorCsv is not None:
+	# 	csv_qv = system.tag.readBlocking(['[PLACEHOLDER_TAG_PROVIDER]YourPath/To/DeviceCSV'])[0]
+	# 	if csv_qv.quality.isGood() and csv_qv.value:
+	# 		response = request['servletResponse']
+	# 		response.setContentType('text/csv')
+	# 		response.setHeader('Content-Disposition', 'attachment; filename="sim_program.csv"')
+	# 		writer = response.getWriter()
+	# 		writer.print(csv_qv.value)
+	# 		writer.flush()
+	# 		return
+	# 	return {'json': {'error': 'No CSV generated.'}}
 
 	# Browse mode: list tag providers or browse a path
 	browse = params.get('browse', None)
@@ -1393,7 +1389,7 @@ def doPost(request, session):
 				"Implement one in your script library and update this endpoint."
 			)
 			response['mirror'] = {'success': True, 'dest': dest}
-		except:
+		except Exception:
 			import traceback
 			response['mirror'] = {'success': False, 'error': traceback.format_exc()}
 
@@ -1403,8 +1399,9 @@ def doPost(request, session):
 		try:
 			system.tag.deleteTags([delPath])
 			response['deleteTags'] = {'success': True}
-		except:
-			response['deleteTags'] = {'success': False}
+		except Exception:
+			import traceback
+			response['deleteTags'] = {'success': False, 'error': traceback.format_exc()}
 
 	# Handle script — call a gateway script function by dotted path
 	if 'script' in data:
@@ -1424,7 +1421,7 @@ def doPost(request, session):
 			func = getattr(mod, funcName)
 			result = func(*scriptArgs, **scriptKwargs)
 			response['script'] = {'success': True, 'result': result}
-		except:
+		except Exception:
 			import traceback
 			response['script'] = {'success': False, 'error': traceback.format_exc()}
 
@@ -1493,7 +1490,7 @@ def doPost(request, session):
 				tagObj['name'] = tagName
 			results = system.tag.configure(basePath, [tagObj], collisionPolicy)
 			response['importTags'] = {'success': True, 'results': str(results)}
-		except:
+		except Exception:
 			import traceback
 			response['importTags'] = {'success': False, 'error': traceback.format_exc()}
 

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -1246,6 +1246,30 @@ write_file "com.inductiveautomation.webdev/resources/testing/run/doPost.py" "$RU
 
 write_file "com.inductiveautomation.webdev/resources/testing/run/config.json" "$WEBDEV_CONFIG_JSON"
 
+# --- run/resource.json (Ignition resource descriptor — required for WebDev to discover the endpoint) ---
+
+WEBDEV_RUN_RESOURCE=$(cat <<'JSONEOF'
+{
+  "scope": "G",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": [
+    "config.json",
+    "doPost.py",
+    "doGet.py"
+  ],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+JSONEOF
+)
+write_file "com.inductiveautomation.webdev/resources/testing/run/resource.json" "$WEBDEV_RUN_RESOURCE"
+
 # --- tags/doGet.py (genericized tag provider + CSV filename) ---
 
 TAGS_DOGET=$(cat <<'PYEOF'
@@ -1531,6 +1555,30 @@ write_file "com.inductiveautomation.webdev/resources/testing/tags/doPost.py" "$T
 # --- tags/config.json ---
 
 write_file "com.inductiveautomation.webdev/resources/testing/tags/config.json" "$WEBDEV_CONFIG_JSON"
+
+# --- tags/resource.json ---
+
+WEBDEV_TAGS_RESOURCE=$(cat <<'JSONEOF'
+{
+  "scope": "G",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": [
+    "config.json",
+    "doPost.py",
+    "doGet.py"
+  ],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+JSONEOF
+)
+write_file "com.inductiveautomation.webdev/resources/testing/tags/resource.json" "$WEBDEV_TAGS_RESOURCE"
 
 
 # ===================================================================

--- a/claude-code-plugin/scripts/scaffold-testing.sh
+++ b/claude-code-plugin/scripts/scaffold-testing.sh
@@ -1,0 +1,1650 @@
+#!/usr/bin/env bash
+# scaffold-testing.sh — Scaffold Jython test framework + WebDev endpoints + type stubs.
+# Part of the Ignition Dev Tools Claude Code plugin.
+#
+# Creates ~25 files across 3 directories:
+#   1. Jython test framework  (ignition/script-python/testing/)
+#   2. WebDev test endpoints   (com.inductiveautomation.webdev/resources/testing/)
+#   3. Type stubs              (.ignition-stubs/testing/)
+#
+# Usage:
+#   scaffold-testing.sh --project-root /path/to/project --project-name MyProject \
+#     [--gateway-url https://localhost:9043] [--tag-provider default] \
+#     [--force] [--dry-run]
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+PROJECT_ROOT="" PROJECT_NAME="" GATEWAY_URL="" TAG_PROVIDER=""
+FORCE=false DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-root)  PROJECT_ROOT="$2";  shift 2 ;;
+    --project-name)  PROJECT_NAME="$2";  shift 2 ;;
+    --gateway-url)   GATEWAY_URL="$2";   shift 2 ;;
+    --tag-provider)  TAG_PROVIDER="$2";  shift 2 ;;
+    --force)         FORCE=true;         shift ;;
+    --dry-run)       DRY_RUN=true;       shift ;;
+    -h|--help)
+      sed -n '2,14s/^# //p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Validate required args
+[[ -z "$PROJECT_ROOT" ]]  && { echo "Error: --project-root required" >&2; exit 1; }
+[[ -z "$PROJECT_NAME" ]]  && { echo "Error: --project-name required" >&2; exit 1; }
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+TAG_PROVIDER="${TAG_PROVIDER:-default}"
+
+# Verify project root exists
+[[ -d "$PROJECT_ROOT" ]] || { echo "Error: project root does not exist: $PROJECT_ROOT" >&2; exit 1; }
+
+CREATED=0 SKIPPED=0
+
+# ---------------------------------------------------------------------------
+# Helper: write a file with existence check
+# ---------------------------------------------------------------------------
+
+write_file() {
+  local filepath="$1"
+  local content="$2"
+  local full_path="$PROJECT_ROOT/$filepath"
+
+  if [[ "$DRY_RUN" = true ]]; then
+    echo "  Would create: $filepath"
+    return
+  fi
+
+  if [[ -f "$full_path" ]] && [[ "$FORCE" != true ]]; then
+    echo "  Skipped (exists): $filepath"
+    SKIPPED=$((SKIPPED + 1))
+    return
+  fi
+
+  mkdir -p "$(dirname "$full_path")"
+  printf '%s' "$content" > "$full_path"
+  CREATED=$((CREATED + 1))
+  echo "  Created: $filepath"
+}
+
+# ---------------------------------------------------------------------------
+# Shared resource.json (identical for all 5 script modules)
+# ---------------------------------------------------------------------------
+
+RESOURCE_JSON=$(cat <<'RJEOF'
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": [
+    "code.py"
+  ],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-02-20T00:00:00Z"
+    },
+    "hintScope": 2
+  }
+}
+RJEOF
+)
+
+# ---------------------------------------------------------------------------
+# Shared WebDev config.json
+# ---------------------------------------------------------------------------
+
+WEBDEV_CONFIG_JSON=$(cat <<'WCEOF'
+{
+  "resource-type": "python-resource",
+  "doGet": {
+    "enabled": true,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPost": {
+    "enabled": true,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPut": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doDelete": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doHead": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doOptions": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doTrace": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  },
+  "doPatch": {
+    "enabled": false,
+    "max-retry-attempts": 3,
+    "require-auth": false,
+    "require-https": false,
+    "required-roles": "",
+    "user-source": ""
+  }
+}
+WCEOF
+)
+
+echo "Scaffolding test framework for project: $PROJECT_NAME"
+echo "  Project root:  $PROJECT_ROOT"
+echo "  Gateway URL:   $GATEWAY_URL"
+echo "  Tag provider:  $TAG_PROVIDER"
+echo ""
+
+# ===================================================================
+# 1. Jython Test Framework — ignition/script-python/testing/
+# ===================================================================
+
+echo "--- Jython Test Framework ---"
+
+# --- runner/code.py (genericized) ---
+
+RUNNER_CODE=$(cat <<'PYEOF'
+"""
+Test runner: discovers and executes @test-decorated functions.
+
+Location: testing.runner
+
+Usage from Script Console:
+	print testing.runner.run_all()
+	print testing.runner.run_module("core.mes.changeover.__tests__")
+
+Usage from WebDev:
+	results = testing.runner.run_all()
+	return {'json': results}
+"""
+
+import time
+import traceback
+
+from java.io import File
+
+
+# ---------------------------------------------------------------------------
+# Configuration — set PROJECT_NAME to your Ignition project folder name.
+# The scaffold script replaces PLACEHOLDER_PROJECT_NAME automatically.
+# ---------------------------------------------------------------------------
+
+PROJECT_NAME = "PLACEHOLDER_PROJECT_NAME"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def run_all(base_package=""):
+	"""Discover and run all test modules under the script library.
+
+	Args:
+		base_package: Dotted package prefix to filter (e.g. "core.mes").
+		              Empty string means run everything.
+
+	Returns:
+		dict: {passed, failed, skipped, errors, duration_ms, results: [...]}
+	"""
+	modules = _discover_test_modules()
+
+	if base_package:
+		modules = [m for m in modules if m.startswith(base_package)]
+
+	all_results = []
+	t0 = time.time()
+
+	for module_path in sorted(modules):
+		module_results = run_module(module_path)
+		all_results.append(module_results)
+
+	elapsed = int((time.time() - t0) * 1000)
+
+	passed = sum(m["passed"] for m in all_results)
+	failed = sum(m["failed"] for m in all_results)
+	skipped = sum(m["skipped"] for m in all_results)
+	errors = sum(m["errors"] for m in all_results)
+
+	return {
+		"passed": passed,
+		"failed": failed,
+		"skipped": skipped,
+		"errors": errors,
+		"total": passed + failed + skipped + errors,
+		"duration_ms": elapsed,
+		"modules": all_results,
+	}
+
+
+def run_module(module_path):
+	"""Import a specific test module and run all @test functions in it.
+
+	Args:
+		module_path: Dotted module path (e.g. "core.mes.changeover.__tests__")
+
+	Returns:
+		dict: {module, passed, failed, skipped, errors, duration_ms, results: [...]}
+	"""
+	result = {
+		"module": module_path,
+		"passed": 0,
+		"failed": 0,
+		"skipped": 0,
+		"errors": 0,
+		"duration_ms": 0,
+		"results": [],
+	}
+
+	t0 = time.time()
+
+	# Import the module
+	try:
+		mod = _import_module(module_path)
+	except Exception as e:
+		result["errors"] = 1
+		result["results"].append({
+			"name": "(module import)",
+			"status": "error",
+			"message": "Failed to import %s: %s" % (module_path, str(e)),
+			"traceback": traceback.format_exc(),
+			"duration_ms": 0,
+		})
+		result["duration_ms"] = int((time.time() - t0) * 1000)
+		return result
+
+	# Find setup/teardown and test functions
+	setup_fn = None
+	teardown_fn = None
+	test_fns = []
+
+	for name in dir(mod):
+		obj = getattr(mod, name)
+		if not callable(obj):
+			continue
+		if getattr(obj, "_is_setup", False):
+			setup_fn = obj
+		elif getattr(obj, "_is_teardown", False):
+			teardown_fn = obj
+		elif getattr(obj, "_is_test", False):
+			test_fns.append((name, obj))
+
+	# Sort tests by name for deterministic ordering
+	test_fns.sort(key=lambda pair: pair[0])
+
+	# Run setup
+	if setup_fn is not None:
+		try:
+			setup_fn()
+		except Exception as e:
+			result["errors"] = 1
+			result["results"].append({
+				"name": "(setup)",
+				"status": "error",
+				"message": "Setup failed: %s" % str(e),
+				"traceback": traceback.format_exc(),
+				"duration_ms": 0,
+			})
+			result["duration_ms"] = int((time.time() - t0) * 1000)
+			return result
+
+	# Run tests
+	for name, func in test_fns:
+		test_result = _run_single_test(name, func)
+		result["results"].append(test_result)
+		status = test_result["status"]
+		if status == "passed":
+			result["passed"] += 1
+		elif status == "failed":
+			result["failed"] += 1
+		elif status == "skipped":
+			result["skipped"] += 1
+		elif status == "error":
+			result["errors"] += 1
+
+	# Run teardown
+	if teardown_fn is not None:
+		try:
+			teardown_fn()
+		except Exception as e:
+			result["results"].append({
+				"name": "(teardown)",
+				"status": "error",
+				"message": "Teardown failed: %s" % str(e),
+				"traceback": traceback.format_exc(),
+				"duration_ms": 0,
+			})
+			result["errors"] += 1
+
+	result["duration_ms"] = int((time.time() - t0) * 1000)
+	return result
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def _discover_test_modules():
+	"""Walk the script library filesystem to find __tests__/code.py modules.
+
+	Looks for both __tests__ (lowercase, new convention) and __TESTS__
+	(uppercase, legacy convention) directories containing code.py.
+
+	Returns:
+		list[str]: Dotted module paths (e.g. ["core.mes.changeover.__tests__"])
+	"""
+	# Ignition project script library root on the gateway filesystem.
+	# The default gateway install path is /usr/local/bin/ignition.
+	# Adjust if your gateway is installed elsewhere.
+	project_dirs = [
+		"/usr/local/bin/ignition/data/projects/" + PROJECT_NAME + "/ignition/script-python",
+	]
+
+	# NOTE: To test discovery locally (outside the gateway), uncomment the
+	# following lines and set the path to your local project checkout:
+	#
+	# local_path = "/path/to/your/local/projects/" + PROJECT_NAME + "/ignition/script-python"
+	# local_file = File(local_path)
+	# if local_file.exists():
+	#     project_dirs.append(local_path)
+
+	modules = []
+	seen = set()
+
+	for base_dir in project_dirs:
+		base_file = File(base_dir)
+		if not base_file.exists():
+			continue
+
+		_walk_for_tests(base_file, base_dir, modules, seen)
+
+	return sorted(modules)
+
+
+def _walk_for_tests(directory, base_dir, modules, seen):
+	"""Recursively walk directory to find __tests__/code.py files.
+
+	Args:
+		directory: java.io.File directory to search
+		base_dir: Root script-python path for computing module names
+		modules: List to append discovered module paths to
+		seen: Set of already-seen module paths (avoids duplicates)
+	"""
+	children = directory.listFiles()
+	if children is None:
+		return
+
+	for child in children:
+		if not child.isDirectory():
+			continue
+
+		name = child.getName()
+
+		# Check if this is a test directory
+		if name in ("__tests__", "__TESTS__"):
+			code_file = File(child, "code.py")
+			if code_file.exists():
+				# Convert filesystem path to dotted module path
+				rel_path = child.getAbsolutePath()[len(base_dir) + 1:]
+				module_path = rel_path.replace("/", ".").replace("\\", ".")
+				if module_path not in seen:
+					seen.add(module_path)
+					modules.append(module_path)
+		else:
+			# Recurse into subdirectories
+			_walk_for_tests(child, base_dir, modules, seen)
+
+
+# ---------------------------------------------------------------------------
+# Import & Execution
+# ---------------------------------------------------------------------------
+
+def _import_module(module_path):
+	"""Import a dotted module path and return the module object.
+
+	Uses Jython's __import__ to load script library modules by their
+	dotted path (e.g. "core.mes.changeover.__tests__").
+
+	Args:
+		module_path: Dotted module path
+
+	Returns:
+		module object
+	"""
+	parts = module_path.split(".")
+	mod = __import__(module_path)
+	# __import__ returns the top-level module; traverse to the leaf
+	for part in parts[1:]:
+		mod = getattr(mod, part)
+	return mod
+
+
+def _run_single_test(name, func):
+	"""Execute a single test function and return its result.
+
+	Handles @skip, @expected_error decorators, and captures exceptions.
+
+	Args:
+		name: Test function name
+		func: The test function
+
+	Returns:
+		dict: {name, status, message, traceback, duration_ms}
+	"""
+	# Check for skip
+	if getattr(func, "_skip", False):
+		reason = getattr(func, "_skip_reason", "")
+		return {
+			"name": name,
+			"status": "skipped",
+			"message": reason,
+			"traceback": None,
+			"duration_ms": 0,
+		}
+
+	expected_error = getattr(func, "_expected_error", None)
+
+	t0 = time.time()
+	try:
+		func()
+		elapsed = int((time.time() - t0) * 1000)
+
+		if expected_error is not None:
+			# Expected an exception but none was raised
+			return {
+				"name": name,
+				"status": "failed",
+				"message": "Expected %s to be raised" % expected_error.__name__,
+				"traceback": None,
+				"duration_ms": elapsed,
+			}
+
+		return {
+			"name": name,
+			"status": "passed",
+			"message": None,
+			"traceback": None,
+			"duration_ms": elapsed,
+		}
+
+	except Exception as e:
+		elapsed = int((time.time() - t0) * 1000)
+
+		if expected_error is not None and isinstance(e, expected_error):
+			return {
+				"name": name,
+				"status": "passed",
+				"message": "Raised expected %s" % expected_error.__name__,
+				"traceback": None,
+				"duration_ms": elapsed,
+			}
+
+		# Determine if this is an assertion failure or an unexpected error
+		from testing.assertions import TestAssertionError
+		if isinstance(e, (TestAssertionError, AssertionError)):
+			status = "failed"
+		else:
+			status = "error"
+
+		return {
+			"name": name,
+			"status": status,
+			"message": str(e),
+			"traceback": traceback.format_exc(),
+			"duration_ms": elapsed,
+		}
+PYEOF
+)
+# Replace placeholder with actual project name
+RUNNER_CODE="${RUNNER_CODE//PLACEHOLDER_PROJECT_NAME/$PROJECT_NAME}"
+write_file "ignition/script-python/testing/runner/code.py" "$RUNNER_CODE"
+write_file "ignition/script-python/testing/runner/resource.json" "$RESOURCE_JSON"
+
+# --- assertions/code.py (generic, used as-is) ---
+
+ASSERTIONS_CODE=$(cat <<'PYEOF'
+"""
+Test assertion functions with descriptive failure messages.
+
+Location: testing.assertions
+
+Usage:
+	from testing.assertions import assert_equal, assert_true, assert_raises
+
+	assert_equal(actual, expected)
+	assert_true(value, "should be truthy")
+	assert_raises(lambda: int("abc"), ValueError)
+"""
+
+
+class TestAssertionError(AssertionError):
+	"""Assertion error with structured context for test reporting."""
+
+	def __init__(self, message, actual=None, expected=None):
+		self.actual = actual
+		self.expected = expected
+		super(TestAssertionError, self).__init__(message)
+
+
+def assert_equal(actual, expected, msg=None):
+	"""Assert actual == expected."""
+	if actual != expected:
+		text = msg or "Expected %r but got %r" % (expected, actual)
+		raise TestAssertionError(text, actual=actual, expected=expected)
+
+
+def assert_not_equal(actual, expected, msg=None):
+	"""Assert actual != expected."""
+	if actual == expected:
+		text = msg or "Expected values to differ but both are %r" % (actual,)
+		raise TestAssertionError(text, actual=actual, expected=expected)
+
+
+def assert_true(val, msg=None):
+	"""Assert val is truthy."""
+	if not val:
+		text = msg or "Expected truthy value but got %r" % (val,)
+		raise TestAssertionError(text, actual=val, expected=True)
+
+
+def assert_false(val, msg=None):
+	"""Assert val is falsy."""
+	if val:
+		text = msg or "Expected falsy value but got %r" % (val,)
+		raise TestAssertionError(text, actual=val, expected=False)
+
+
+def assert_none(val, msg=None):
+	"""Assert val is None."""
+	if val is not None:
+		text = msg or "Expected None but got %r" % (val,)
+		raise TestAssertionError(text, actual=val, expected=None)
+
+
+def assert_not_none(val, msg=None):
+	"""Assert val is not None."""
+	if val is None:
+		text = msg or "Expected a value but got None"
+		raise TestAssertionError(text, actual=None, expected="not None")
+
+
+def assert_close(actual, expected, tolerance=0.001, msg=None):
+	"""Assert actual is within tolerance of expected (for floating point).
+
+	Args:
+		actual: Actual numeric value
+		expected: Expected numeric value
+		tolerance: Maximum allowed absolute difference (default 0.001)
+		msg: Optional failure message
+	"""
+	diff = abs(actual - expected)
+	if diff > tolerance:
+		text = msg or "Expected %r within %s of %r (diff=%s)" % (
+			actual, tolerance, expected, diff
+		)
+		raise TestAssertionError(text, actual=actual, expected=expected)
+
+
+def assert_raises(callable_fn, exception_type, msg=None):
+	"""Assert that calling callable_fn raises the given exception type.
+
+	Args:
+		callable_fn: Zero-argument callable to invoke
+		exception_type: Expected exception class
+		msg: Optional failure message
+
+	Returns:
+		The caught exception instance (for further inspection)
+	"""
+	try:
+		callable_fn()
+	except exception_type as e:
+		return e
+	except Exception as e:
+		text = msg or "Expected %s but got %s: %s" % (
+			exception_type.__name__, type(e).__name__, str(e)
+		)
+		raise TestAssertionError(text, actual=type(e).__name__, expected=exception_type.__name__)
+	else:
+		text = msg or "Expected %s to be raised but nothing was raised" % (
+			exception_type.__name__,
+		)
+		raise TestAssertionError(text, actual="no exception", expected=exception_type.__name__)
+
+
+def assert_tag_value(tag_path, expected, msg=None):
+	"""Read a real gateway tag and assert its value equals expected.
+
+	Args:
+		tag_path: Full tag path (e.g. '[default]Path/To/Tag')
+		expected: Expected value
+		msg: Optional failure message
+	"""
+	qv = system.tag.readBlocking([tag_path])[0]
+	actual = qv.value
+	if actual != expected:
+		text = msg or "Tag '%s' expected %r but got %r (quality=%s)" % (
+			tag_path, expected, actual, qv.quality
+		)
+		raise TestAssertionError(text, actual=actual, expected=expected)
+
+
+def assert_contains(container, item, msg=None):
+	"""Assert that item is in container."""
+	if item not in container:
+		text = msg or "Expected %r to contain %r" % (container, item)
+		raise TestAssertionError(text, actual=container, expected=item)
+
+
+def assert_isinstance(obj, expected_type, msg=None):
+	"""Assert that obj is an instance of expected_type."""
+	if not isinstance(obj, expected_type):
+		text = msg or "Expected instance of %s but got %s" % (
+			expected_type.__name__, type(obj).__name__
+		)
+		raise TestAssertionError(text, actual=type(obj).__name__, expected=expected_type.__name__)
+PYEOF
+)
+write_file "ignition/script-python/testing/assertions/code.py" "$ASSERTIONS_CODE"
+write_file "ignition/script-python/testing/assertions/resource.json" "$RESOURCE_JSON"
+
+# --- decorators/code.py (generic, used as-is) ---
+
+DECORATORS_CODE=$(cat <<'PYEOF'
+"""
+Test decorators for marking functions as tests.
+
+Location: testing.decorators
+
+Usage:
+	from testing.decorators import test, skip, setup, teardown, expected_error
+
+	@test
+	def my_test():
+		assert_equal(1 + 1, 2)
+
+	@skip("not implemented yet")
+	@test
+	def future_test():
+		pass
+
+	@expected_error(ValueError)
+	@test
+	def test_bad_input():
+		int("abc")
+"""
+
+
+def test(func):
+	"""Mark a function as a test case.
+
+	Sets _is_test = True on the function so the runner can discover it.
+	"""
+	func._is_test = True
+	return func
+
+
+def skip(reason=""):
+	"""Mark a test to be skipped during execution.
+
+	Args:
+		reason: Optional explanation for why the test is skipped
+
+	Usage:
+		@skip("waiting on tag config")
+		@test
+		def test_something():
+			pass
+	"""
+	def decorator(func):
+		func._skip = True
+		func._skip_reason = reason
+		return func
+	return decorator
+
+
+def setup(func):
+	"""Mark a function as module-level setup (runs before all tests)."""
+	func._is_setup = True
+	return func
+
+
+def teardown(func):
+	"""Mark a function as module-level teardown (runs after all tests)."""
+	func._is_teardown = True
+	return func
+
+
+def expected_error(exception_type):
+	"""Mark a test that should raise a specific exception type.
+
+	The test passes if the expected exception is raised, fails otherwise.
+
+	Args:
+		exception_type: The exception class expected (e.g. ValueError, KeyError)
+
+	Usage:
+		@expected_error(ValueError)
+		@test
+		def test_bad_parse():
+			int("not a number")
+	"""
+	def decorator(func):
+		func._expected_error = exception_type
+		return func
+	return decorator
+PYEOF
+)
+write_file "ignition/script-python/testing/decorators/code.py" "$DECORATORS_CODE"
+write_file "ignition/script-python/testing/decorators/resource.json" "$RESOURCE_JSON"
+
+# --- helpers/code.py (stripped: keep only write_dataset_tag + clear_dataset_tag) ---
+
+HELPERS_CODE=$(cat <<'PYEOF'
+"""
+Helper functions callable from E2E tests via the callScript endpoint.
+
+These bridge the gap between the testing/tags WebDev endpoint (which writes
+raw JSON values) and Ignition tag types that need native objects (DataSets,
+etc.).
+"""
+import system
+
+
+def write_dataset_tag(tag_path, columns, types, rows):
+	"""Write a real Ignition DataSet to a tag.
+
+	The testing/tags endpoint writes raw JSON which doesn't produce a native
+	DataSet object.  This helper uses system.dataset.toDataSet() to create
+	a proper DataSet, then writes it via system.tag.writeBlocking().
+
+	Args:
+		tag_path (str): Full tag path, e.g. "[default]Path/To/Tag".
+		columns (list[str]): Column header names.
+		types (list[str]): Column type names matching Ignition types
+			(String, Float8, Int4, Boolean, DateTime, etc.).
+		rows (list[list]): Row data — each inner list matches column order.
+
+	Returns:
+		dict: {"success": True/False, "rowCount": int, "error": str or None}
+	"""
+	try:
+		# Coerce row values to match declared types
+		type_coerce = {
+			"String": str,
+			"Float8": float,
+			"Float4": float,
+			"Int4": int,
+			"Int8": int,
+			"Boolean": bool,
+		}
+		coerced_rows = []
+		for row in rows:
+			new_row = []
+			for j, val in enumerate(row):
+				t = types[j] if j < len(types) else "String"
+				fn = type_coerce.get(t)
+				new_row.append(fn(val) if fn and val is not None else val)
+			coerced_rows.append(new_row)
+
+		ds = system.dataset.toDataSet(columns, coerced_rows)
+
+		# Try writing the DataSet directly first.
+		results = system.tag.writeBlocking([tag_path], [ds])
+		success = results[0].isGood()
+
+		if success:
+			# Verify the read-back is actually a DataSet (not a toString'd string)
+			readback = system.tag.readBlocking([tag_path])[0].value
+			if readback is not None and hasattr(readback, 'getRowCount'):
+				return {
+					"success": True,
+					"rowCount": ds.getRowCount(),
+					"error": None,
+				}
+
+			# Tag is String type — Ignition stored the DataSet's toString().
+			# Re-configure the tag as DataSet type and retry.
+			base_path = tag_path[:tag_path.rfind('/')]
+			tag_name = tag_path[tag_path.rfind('/') + 1:]
+			system.tag.configure(base_path, [{
+				"name": tag_name,
+				"dataType": "DataSet",
+				"valueSource": "memory",
+			}], "o")
+
+			# Retry write with DataSet type
+			results = system.tag.writeBlocking([tag_path], [ds])
+			success = results[0].isGood()
+
+		return {
+			"success": success,
+			"rowCount": ds.getRowCount(),
+			"error": None if success else str(results[0]),
+		}
+	except:
+		import traceback
+		return {
+			"success": False,
+			"rowCount": 0,
+			"error": traceback.format_exc(),
+		}
+
+
+def clear_dataset_tag(tag_path, columns, types):
+	"""Write an empty DataSet to a tag.
+
+	Args:
+		tag_path (str): Full tag path.
+		columns (list[str]): Column header names.
+		types (list[str]): Column type names.
+
+	Returns:
+		dict: {"success": True/False, "error": str or None}
+	"""
+	return write_dataset_tag(tag_path, columns, types, [])
+PYEOF
+)
+write_file "ignition/script-python/testing/helpers/code.py" "$HELPERS_CODE"
+write_file "ignition/script-python/testing/helpers/resource.json" "$RESOURCE_JSON"
+
+# --- reporter/code.py (generic, used as-is) ---
+
+REPORTER_CODE=$(cat <<'PYEOF'
+"""
+Test result formatters: JSON, JUnit XML, and console output.
+
+Location: testing.reporter
+
+Usage:
+	results = testing.runner.run_all()
+	print testing.reporter.to_console(results)
+	xml = testing.reporter.to_junit_xml(results)
+	json_str = testing.reporter.to_json(results)
+"""
+
+import json
+import time
+
+
+def to_json(results):
+	"""Serialize test results to a JSON string.
+
+	Args:
+		results: Dict from testing.runner.run_all() or run_module()
+
+	Returns:
+		str: JSON string
+	"""
+	return json.dumps(results, indent=2)
+
+
+def to_console(results):
+	"""Format test results as human-readable text for the Script Console.
+
+	Args:
+		results: Dict from testing.runner.run_all()
+
+	Returns:
+		str: Formatted text output
+	"""
+	lines = []
+	lines.append("=" * 60)
+	lines.append("TEST RESULTS")
+	lines.append("=" * 60)
+
+	modules = results.get("modules", [])
+	if not modules:
+		# Single module result (from run_module)
+		modules = [results]
+
+	for mod in modules:
+		module_name = mod.get("module", "unknown")
+		lines.append("")
+		lines.append("--- %s ---" % module_name)
+
+		for r in mod.get("results", []):
+			status = r["status"].upper()
+			name = r["name"]
+
+			if status == "PASSED":
+				marker = "  PASS"
+			elif status == "FAILED":
+				marker = "  FAIL"
+			elif status == "SKIPPED":
+				marker = "  SKIP"
+			else:
+				marker = " ERROR"
+
+			line = "%s  %s" % (marker, name)
+			if r.get("duration_ms", 0) > 0:
+				line += "  (%dms)" % r["duration_ms"]
+			lines.append(line)
+
+			if r.get("message") and status in ("FAILED", "ERROR"):
+				lines.append("         %s" % r["message"])
+
+	lines.append("")
+	lines.append("=" * 60)
+	lines.append(
+		"Total: %d  Passed: %d  Failed: %d  Skipped: %d  Errors: %d  (%dms)" % (
+			results.get("total", 0),
+			results.get("passed", 0),
+			results.get("failed", 0),
+			results.get("skipped", 0),
+			results.get("errors", 0),
+			results.get("duration_ms", 0),
+		)
+	)
+	lines.append("=" * 60)
+
+	return "\n".join(lines)
+
+
+def to_junit_xml(results):
+	"""Format test results as JUnit XML for CI integration.
+
+	Args:
+		results: Dict from testing.runner.run_all()
+
+	Returns:
+		str: JUnit XML string
+	"""
+	modules = results.get("modules", [])
+	if not modules:
+		modules = [results]
+
+	xml_parts = ['<?xml version="1.0" encoding="UTF-8"?>']
+	xml_parts.append('<testsuites tests="%d" failures="%d" errors="%d" skipped="%d" time="%.3f">' % (
+		results.get("total", 0),
+		results.get("failed", 0),
+		results.get("errors", 0),
+		results.get("skipped", 0),
+		results.get("duration_ms", 0) / 1000.0,
+	))
+
+	for mod in modules:
+		module_name = mod.get("module", "unknown")
+		test_results = mod.get("results", [])
+
+		mod_failures = mod.get("failed", 0)
+		mod_errors = mod.get("errors", 0)
+		mod_skipped = mod.get("skipped", 0)
+		mod_tests = len(test_results)
+		mod_time = mod.get("duration_ms", 0) / 1000.0
+
+		xml_parts.append(
+			'  <testsuite name="%s" tests="%d" failures="%d" errors="%d" skipped="%d" time="%.3f">'
+			% (_escape_xml(module_name), mod_tests, mod_failures, mod_errors, mod_skipped, mod_time)
+		)
+
+		for r in test_results:
+			name = r.get("name", "unknown")
+			t = r.get("duration_ms", 0) / 1000.0
+			status = r.get("status", "error")
+
+			xml_parts.append(
+				'    <testcase name="%s" classname="%s" time="%.3f">'
+				% (_escape_xml(name), _escape_xml(module_name), t)
+			)
+
+			if status == "failed":
+				msg = _escape_xml(r.get("message", ""))
+				tb = _escape_xml(r.get("traceback", "") or "")
+				xml_parts.append('      <failure message="%s">%s</failure>' % (msg, tb))
+			elif status == "error":
+				msg = _escape_xml(r.get("message", ""))
+				tb = _escape_xml(r.get("traceback", "") or "")
+				xml_parts.append('      <error message="%s">%s</error>' % (msg, tb))
+			elif status == "skipped":
+				reason = _escape_xml(r.get("message", ""))
+				xml_parts.append('      <skipped message="%s" />' % reason)
+
+			xml_parts.append('    </testcase>')
+
+		xml_parts.append('  </testsuite>')
+
+	xml_parts.append('</testsuites>')
+
+	return "\n".join(xml_parts)
+
+
+def _escape_xml(text):
+	"""Escape special XML characters."""
+	if text is None:
+		return ""
+	text = str(text)
+	text = text.replace("&", "&amp;")
+	text = text.replace("<", "&lt;")
+	text = text.replace(">", "&gt;")
+	text = text.replace('"', "&quot;")
+	return text
+PYEOF
+)
+write_file "ignition/script-python/testing/reporter/code.py" "$REPORTER_CODE"
+write_file "ignition/script-python/testing/reporter/resource.json" "$RESOURCE_JSON"
+
+
+# ===================================================================
+# 2. WebDev Test Endpoints — com.inductiveautomation.webdev/resources/testing/
+# ===================================================================
+
+echo ""
+echo "--- WebDev Test Endpoints ---"
+
+# --- run/doGet.py (genericized project name) ---
+
+RUN_DOGET=$(cat <<'PYEOF'
+def doGet(request, session):
+	"""Return usage information for the test runner endpoint.
+
+	GET /data/testing/run - shows this help
+	GET /data/testing/run?discover=true - lists discovered test modules
+	"""
+	params = request.get("params", {})
+	discover = "discover" in params
+
+	if discover:
+		try:
+			modules = testing.runner._discover_test_modules()
+			return {"json": {
+				"discovered_modules": modules,
+				"count": len(modules),
+			}}
+		except Exception as e:
+			import traceback
+			return {"json": {
+				"error": str(e),
+				"traceback": traceback.format_exc(),
+			}}
+
+	return {"json": {
+		"name": "PLACEHOLDER_PROJECT_NAME — Test Runner",
+		"usage": {
+			"run_all": "POST /data/testing/run",
+			"run_module": "POST /data/testing/run?module=core.mes.changeover.__tests__",
+			"run_package": "POST /data/testing/run?package=core.mes",
+			"formats": "Add ?format=json|junit|text",
+			"discover": "GET /data/testing/run?discover=true",
+		},
+	}}
+PYEOF
+)
+RUN_DOGET="${RUN_DOGET//PLACEHOLDER_PROJECT_NAME/$PROJECT_NAME}"
+write_file "com.inductiveautomation.webdev/resources/testing/run/doGet.py" "$RUN_DOGET"
+
+# --- run/doPost.py (generic, used as-is) ---
+
+RUN_DOPOST=$(cat <<'PYEOF'
+def doPost(request, session):
+	"""Run tests and return JSON results.
+
+	Query params:
+		module  - Dotted module path to run specific tests
+		         (e.g. "core.mes.changeover.__tests__")
+		package - Dotted package prefix to filter
+		         (e.g. "core.mes")
+		format  - Output format: "json" (default), "junit", "text"
+
+	POST body (JSON, optional):
+		{"module": "...", "package": "...", "format": "..."}
+
+	Returns:
+		200 if all tests pass
+		207 if there are failures or errors
+		500 on runner error
+	"""
+	import json
+
+	# Parse params from query string or POST body
+	module = None
+	package = ""
+	fmt = "json"
+
+	params = request.get("params", {})
+	if params:
+		module = _get_param(params, "module")
+		package = _get_param(params, "package") or ""
+		fmt = _get_param(params, "format") or "json"
+
+	# Also check POST body
+	body = request.get("data", None)
+	if body:
+		try:
+			if hasattr(body, 'read'):
+				body = body.read()
+			body_data = json.loads(body)
+			if isinstance(body_data, dict):
+				module = body_data.get("module", module)
+				package = body_data.get("package", package)
+				fmt = body_data.get("format", fmt)
+		except Exception:
+			pass
+
+	try:
+		if module:
+			results = testing.runner.run_module(module)
+			# Wrap single module in the run_all structure
+			results = {
+				"passed": results["passed"],
+				"failed": results["failed"],
+				"skipped": results["skipped"],
+				"errors": results["errors"],
+				"total": results["passed"] + results["failed"] + results["skipped"] + results["errors"],
+				"duration_ms": results["duration_ms"],
+				"modules": [results],
+			}
+		else:
+			results = testing.runner.run_all(base_package=package)
+
+		if fmt == "junit":
+			xml = testing.reporter.to_junit_xml(results)
+			return {
+				"html": xml,
+				"content-type": "application/xml",
+			}
+		elif fmt == "text":
+			text = testing.reporter.to_console(results)
+			return {
+				"html": "<pre>%s</pre>" % text,
+				"content-type": "text/plain",
+			}
+
+		# Default JSON
+		status = 200 if results["failed"] == 0 and results["errors"] == 0 else 207
+		return {"json": results}
+
+	except Exception as e:
+		import traceback
+		return {"json": {
+			"error": str(e),
+			"traceback": traceback.format_exc(),
+		}}
+
+
+def _get_param(params, key):
+	"""Extract a single query param value from Ignition WebDev params.
+
+	Ignition WebDev params are Java String[] arrays. Indexing [0] on a
+	plain string returns the first character, so we must check the type.
+	"""
+	val = params.get(key)
+	if val is None:
+		return None
+	# Convert to string first — handles Java String and Python str
+	s = str(val)
+	# Java String[] arrays stringify as '[value]', plain strings don't
+	# The safest check: if it looks like an array, use .toString() on element
+	try:
+		# Try treating as a Java array — getClass().isArray() works in Jython
+		if hasattr(val, 'getClass') and val.getClass().isArray():
+			from java.lang.reflect import Array
+			if Array.getLength(val) > 0:
+				return str(Array.get(val, 0))
+			return None
+	except Exception:
+		pass
+	# If it's a Python list/tuple, take first element
+	if isinstance(val, (list, tuple)):
+		return str(val[0]) if val else None
+	# Already a string
+	return s
+PYEOF
+)
+write_file "com.inductiveautomation.webdev/resources/testing/run/doPost.py" "$RUN_DOPOST"
+
+# --- run/config.json ---
+
+write_file "com.inductiveautomation.webdev/resources/testing/run/config.json" "$WEBDEV_CONFIG_JSON"
+
+# --- tags/doGet.py (genericized tag provider + CSV filename) ---
+
+TAGS_DOGET=$(cat <<'PYEOF'
+def doGet(request, session):
+	params = request.get('params', {})
+
+	# Simulator CSV download
+	simulatorCsv = params.get('simulatorCsv', None)
+	if simulatorCsv is not None:
+		csv_qv = system.tag.readBlocking(['[PLACEHOLDER_TAG_PROVIDER]WH/Systems/Simulation/DeviceCSV'])[0]
+		if csv_qv.quality.isGood() and csv_qv.value:
+			# Write CSV directly to servlet response for proper Content-Type
+			response = request['servletResponse']
+			response.setContentType('text/csv')
+			response.setHeader('Content-Disposition', 'attachment; filename="PLACEHOLDER_PROJECT_NAME_Sim_program.csv"')
+			writer = response.getWriter()
+			writer.print(csv_qv.value)
+			writer.flush()
+			return
+		return {'json': {'error': 'No CSV generated. Run controller.enable(mode="device") first.'}}
+
+	# Browse mode: list tag providers or browse a path
+	browse = params.get('browse', None)
+	if browse is not None:
+		# Handle Java String[] from query params
+		from java.lang.reflect import Array
+		if hasattr(browse, '__len__') and not isinstance(browse, (str, unicode)):
+			browse = Array.get(browse, 0)
+
+		if browse == '' or browse == 'providers':
+			# List top-level tag providers
+			results = system.tag.browse('')
+			providers = []
+			for r in results.getResults():
+				providers.append(str(r))
+			return {'json': {'providers': providers}}
+		else:
+			# Browse a specific path
+			results = system.tag.browse(browse)
+			tags = []
+			for r in results.getResults():
+				tags.append(str(r))
+			return {'json': {'path': browse, 'tags': tags}}
+
+	return {'json': {
+		'endpoint': 'testing/tags',
+		'description': 'Read/write tags for E2E testing',
+		'usage': {
+			'GET': {
+				'browse': '?browse=providers or ?browse=[default]Path',
+				'simulatorCsv': '?simulatorCsv=true - download device simulator CSV program'
+			},
+			'POST': {
+				'writes': [{'path': '[default]Tag/Path', 'value': 'someValue'}],
+				'reads': ['[default]Tag/Path']
+			}
+		}
+	}}
+PYEOF
+)
+TAGS_DOGET="${TAGS_DOGET//PLACEHOLDER_TAG_PROVIDER/$TAG_PROVIDER}"
+TAGS_DOGET="${TAGS_DOGET//PLACEHOLDER_PROJECT_NAME/$PROJECT_NAME}"
+write_file "com.inductiveautomation.webdev/resources/testing/tags/doGet.py" "$TAGS_DOGET"
+
+# --- tags/doPost.py (genericized paths + mirror comment) ---
+
+TAGS_DOPOST=$(cat <<'PYEOF'
+def doPost(request, session):
+	"""Read/write tags for E2E testing. Auto-creates missing tags.
+
+	POST body: { "writes": [{"path": "[default]Tag/Path", "value": "someValue"}, ...] }
+	Response:  { "results": [{"path": "...", "success": true}, ...] }
+
+	Also supports reading: { "reads": ["[default]Tag/Path", ...] }
+	Response:  { "values": {"[default]Tag/Path": {"value": ..., "quality": ...}} }
+
+	Mirror OPC tags to memory (for testing without PLC):
+	  { "mirror": {"source": "[provider]Path/To/Folder", "dest": "[provider]Path/To/Folder_MEM"} }
+	  Response: { "mirror": {"success": true, "dest": "..."} }
+
+	Delete mirrored tags:
+	  { "deleteTags": "[provider]Path/To/Folder_MEM" }
+	  Response: { "deleteTags": {"success": true} }
+
+	Call a gateway script function (for testing real scripts end-to-end):
+	  { "script": {"path": "core.mes.mashing.enzyme_entry.validate_and_submit", "args": [1, 1, 5.0, "gal", "LOT-001"]} }
+	  Response: { "script": {"success": true, "result": {...}} }
+	"""
+	import json
+
+	data = request['data']
+	if isinstance(data, (str, unicode)):
+		data = system.util.jsonDecode(data)
+
+	response = {}
+
+	# Handle mirror — clone OPC subtree as memory tags.
+	# NOTE: This requires a `convert_to_memory_tags(source, dest)` function in
+	# your project's script library.  The function should browse the source OPC
+	# tag tree and recreate it under dest with valueSource="memory".
+	# If you don't need mirror functionality, you can safely remove this block.
+	if 'mirror' in data:
+		mirrorCfg = data['mirror']
+		source = mirrorCfg['source']
+		dest = mirrorCfg.get('dest', source + '_MEM')
+		try:
+			# TODO: Replace with your project's convert_to_memory_tags function.
+			# Example: your_project.tools.conversions.convert_to_memory_tags(source, dest)
+			raise NotImplementedError(
+				"Mirror requires a convert_to_memory_tags(source, dest) function. "
+				"Implement one in your script library and update this endpoint."
+			)
+			response['mirror'] = {'success': True, 'dest': dest}
+		except:
+			import traceback
+			response['mirror'] = {'success': False, 'error': traceback.format_exc()}
+
+	# Handle deleteTags — remove a tag tree (for cleanup after mirror)
+	if 'deleteTags' in data:
+		delPath = data['deleteTags']
+		try:
+			system.tag.deleteTags([delPath])
+			response['deleteTags'] = {'success': True}
+		except:
+			response['deleteTags'] = {'success': False}
+
+	# Handle script — call a gateway script function by dotted path
+	if 'script' in data:
+		scriptCfg = data['script']
+		scriptPath = scriptCfg['path']
+		scriptArgs = scriptCfg.get('args', [])
+		scriptKwargs = scriptCfg.get('kwargs', {})
+		try:
+			# Resolve the function from dotted path, e.g. "core.mes.mashing.enzyme_entry.validate_and_submit"
+			parts = scriptPath.split('.')
+			funcName = parts[-1]
+			modulePath = '.'.join(parts[:-1])
+			# Navigate the module hierarchy
+			mod = __import__(modulePath)
+			for comp in parts[1:-1]:
+				mod = getattr(mod, comp)
+			func = getattr(mod, funcName)
+			result = func(*scriptArgs, **scriptKwargs)
+			response['script'] = {'success': True, 'result': result}
+		except:
+			import traceback
+			response['script'] = {'success': False, 'error': traceback.format_exc()}
+
+	# Handle writes — auto-create tags if they don't exist
+	if 'writes' in data:
+		paths = []
+		values = []
+		for w in data['writes']:
+			paths.append(w['path'])
+			values.append(w['value'])
+
+		# First attempt: write directly
+		writeResults = system.tag.writeBlocking(paths, values)
+		results = []
+		needCreate = []
+
+		for i, qc in enumerate(writeResults):
+			if qc.isGood():
+				results.append({
+					'path': paths[i],
+					'success': True,
+					'quality': str(qc)
+				})
+			else:
+				# Tag probably doesn't exist — queue for creation
+				needCreate.append(i)
+				results.append(None)  # placeholder
+
+		# Create missing tags and retry writes
+		if needCreate:
+			for idx in needCreate:
+				tagPath = paths[idx]
+				tagValue = values[idx]
+				_ensureTag(tagPath, tagValue)
+
+			# Retry writes for created tags
+			retryPaths = [paths[i] for i in needCreate]
+			retryValues = [values[i] for i in needCreate]
+			retryResults = system.tag.writeBlocking(retryPaths, retryValues)
+
+			for j, idx in enumerate(needCreate):
+				qc = retryResults[j]
+				results[idx] = {
+					'path': paths[idx],
+					'success': qc.isGood(),
+					'quality': str(qc)
+				}
+
+		response['results'] = results
+
+	# Handle importTags — import tag JSON file into the provider via system.tag.configure
+	if 'importTags' in data:
+		importCfg = data['importTags']
+		filePath = importCfg['filePath']
+		basePath = importCfg['basePath']
+		tagName = importCfg.get('tagName', None)
+		collisionPolicy = importCfg.get('collisionPolicy', 'o')
+		try:
+			import os
+			projectRoot = '/usr/local/bin/ignition/data/projects/PLACEHOLDER_PROJECT_NAME'
+			fullPath = os.path.join(projectRoot, filePath)
+			with open(fullPath, 'r') as f:
+				tagJson = f.read()
+			tagObj = system.util.jsonDecode(tagJson)
+			if tagName:
+				tagObj['name'] = tagName
+			results = system.tag.configure(basePath, [tagObj], collisionPolicy)
+			response['importTags'] = {'success': True, 'results': str(results)}
+		except:
+			import traceback
+			response['importTags'] = {'success': False, 'error': traceback.format_exc()}
+
+	# Handle reads
+	if 'reads' in data:
+		tagPaths = data['reads']
+		tagValues = system.tag.readBlocking(tagPaths)
+		values = {}
+		for i, qv in enumerate(tagValues):
+			values[tagPaths[i]] = {
+				'value': qv.value,
+				'quality': str(qv.quality),
+				'good': qv.quality.isGood()
+			}
+		response['values'] = values
+
+	return {'json': response}
+
+
+def _ensureTag(tagPath, value):
+	"""Create a memory tag at the given path if it doesn't exist.
+
+	Parses the path to extract provider, folder structure, and tag name.
+	Creates the full folder hierarchy and a memory tag of the appropriate type.
+	"""
+	# Parse "[provider]Folder/SubFolder/TagName"
+	providerEnd = tagPath.index(']') + 1
+	provider = tagPath[1:providerEnd - 1]  # e.g. "default"
+	remainingPath = tagPath[providerEnd:]   # e.g. "Changeover/cooker/state"
+
+	parts = remainingPath.split('/')
+	tagName = parts[-1]
+	folderParts = parts[:-1]
+
+	# Determine tag data type from value
+	dataType = _inferDataType(value)
+
+	# Build the base path for system.tag.configure
+	basePath = tagPath[:tagPath.rfind('/')]
+
+	# Create tag configuration
+	tagConfig = {
+		'name': tagName,
+		'tagType': 'AtomicTag',
+		'dataType': dataType,
+		'value': value
+	}
+
+	# system.tag.configure creates parent folders automatically
+	result = system.tag.configure(basePath, [tagConfig], 'o')  # 'o' = overwrite if exists
+	return result
+
+
+def _inferDataType(value):
+	"""Infer Ignition tag data type from a Python value."""
+	if isinstance(value, bool):
+		return 'Boolean'
+	elif isinstance(value, int):
+		return 'Int4'
+	elif isinstance(value, float):
+		return 'Float8'
+	else:
+		return 'String'
+PYEOF
+)
+TAGS_DOPOST="${TAGS_DOPOST//PLACEHOLDER_PROJECT_NAME/$PROJECT_NAME}"
+write_file "com.inductiveautomation.webdev/resources/testing/tags/doPost.py" "$TAGS_DOPOST"
+
+# --- tags/config.json ---
+
+write_file "com.inductiveautomation.webdev/resources/testing/tags/config.json" "$WEBDEV_CONFIG_JSON"
+
+
+# ===================================================================
+# 3. Type Stubs — .ignition-stubs/testing/
+# ===================================================================
+
+echo ""
+echo "--- Type Stubs ---"
+
+# --- __init__.pyi ---
+
+write_file ".ignition-stubs/testing/__init__.pyi" ""
+
+# --- assertions.pyi ---
+
+ASSERTIONS_PYI=$(cat <<'PYIEOF'
+from typing import Any
+
+def assert_equal(actual, expected, msg=...) -> Any: ...
+
+def assert_not_equal(actual, expected, msg=...) -> Any: ...
+
+def assert_true(val, msg=...) -> Any: ...
+
+def assert_false(val, msg=...) -> Any: ...
+
+def assert_none(val, msg=...) -> Any: ...
+
+def assert_not_none(val, msg=...) -> Any: ...
+
+def assert_close(actual, expected, tolerance=..., msg=...) -> Any: ...
+
+def assert_raises(callable_fn, exception_type, msg=...) -> Any: ...
+
+def assert_tag_value(tag_path, expected, msg=...) -> Any: ...
+
+def assert_contains(container, item, msg=...) -> Any: ...
+
+def assert_isinstance(obj, expected_type, msg=...) -> Any: ...
+
+class TestAssertionError(AssertionError):
+    def __init__(self, message, actual=..., expected=...) -> Any: ...
+PYIEOF
+)
+write_file ".ignition-stubs/testing/assertions.pyi" "$ASSERTIONS_PYI"
+
+# --- decorators.pyi ---
+
+DECORATORS_PYI=$(cat <<'PYIEOF'
+from typing import Any
+
+def test(func) -> Any: ...
+
+def skip(reason=...) -> Any: ...
+
+def setup(func) -> Any: ...
+
+def teardown(func) -> Any: ...
+
+def expected_error(exception_type) -> Any: ...
+PYIEOF
+)
+write_file ".ignition-stubs/testing/decorators.pyi" "$DECORATORS_PYI"
+
+# --- helpers.pyi (stripped: no run_process_queue or _run_process_queue_direct) ---
+
+HELPERS_PYI=$(cat <<'PYIEOF'
+from typing import Any
+
+def write_dataset_tag(tag_path, columns, types, rows) -> Any: ...
+
+def clear_dataset_tag(tag_path, columns, types) -> Any: ...
+PYIEOF
+)
+write_file ".ignition-stubs/testing/helpers.pyi" "$HELPERS_PYI"
+
+# --- reporter.pyi ---
+
+REPORTER_PYI=$(cat <<'PYIEOF'
+from typing import Any
+
+def to_json(results) -> Any: ...
+
+def to_console(results) -> Any: ...
+
+def to_junit_xml(results) -> Any: ...
+
+def _escape_xml(text) -> Any: ...
+PYIEOF
+)
+write_file ".ignition-stubs/testing/reporter.pyi" "$REPORTER_PYI"
+
+# --- runner.pyi ---
+
+RUNNER_PYI=$(cat <<'PYIEOF'
+from typing import Any
+
+def run_all(base_package=...) -> Any: ...
+
+def run_module(module_path) -> Any: ...
+
+def _discover_test_modules() -> Any: ...
+
+def _walk_for_tests(directory, base_dir, modules, seen) -> Any: ...
+
+def _import_module(module_path) -> Any: ...
+
+def _run_single_test(name, func) -> Any: ...
+PYIEOF
+)
+write_file ".ignition-stubs/testing/runner.pyi" "$RUNNER_PYI"
+
+
+# ===================================================================
+# Summary
+# ===================================================================
+
+echo ""
+if [[ "$DRY_RUN" = true ]]; then
+  echo "Dry run complete. No files were written."
+else
+  echo "Scaffold complete: $CREATED created, $SKIPPED skipped."
+fi

--- a/claude-code-plugin/skills/ignition-api/SKILL.md
+++ b/claude-code-plugin/skills/ignition-api/SKILL.md
@@ -106,16 +106,26 @@ core/util/
 
 **NEVER put a `code.py` in a directory that also contains child packages.** Ignition treats a directory with `code.py` as a leaf module. If you also put subdirectories in it, the behavior is undefined and the child modules may not be importable.
 
+**Exception:** `__tests__/` directories are special — Ignition's script runtime ignores directories whose names start with `__`, so they do not conflict with a sibling `code.py`. The testing framework relies on this convention.
+
 ```
 WRONG:
 my_package/
 ├── code.py          ← has real code
 ├── resource.json
-└── __tests__/       ← child directory — conflicts with code.py above
+└── utils/           ← real child package — conflicts with code.py above
     ├── code.py
     └── resource.json
 
-CORRECT:
+OK (special case):
+my_package/
+├── code.py          ← has real code
+├── resource.json
+└── __tests__/       ← ignored by Ignition runtime, used by test framework
+    ├── code.py
+    └── resource.json
+
+CORRECT (general pattern):
 my_package/
 ├── resource.json    ← package node, no code.py
 ├── logic/

--- a/claude-code-plugin/skills/ignition-api/SKILL.md
+++ b/claude-code-plugin/skills/ignition-api/SKILL.md
@@ -7,6 +7,80 @@ user-invocable: false
 
 You are writing code for **Ignition SCADA** by Inductive Automation. Scripts run in **Jython 2.7** (Python 2.7 on JVM). The scripting API is `system.*`.
 
+## CRITICAL: resource.json Required for EVERY Ignition Resource
+
+**Every file or directory you create inside an Ignition project MUST have a `resource.json`.** Without it, the gateway silently ignores the resource — no error, no warning, it simply doesn't exist at runtime. This is the #1 cause of "not found" errors when managing Ignition projects via git.
+
+This applies to ALL resource types:
+
+| Resource type | Where | resource.json goes |
+|---------------|-------|--------------------|
+| **Script modules** | `ignition/script-python/my_package/` | Next to `code.py` in every directory in the path |
+| **Script sub-packages** | `ignition/script-python/my_package/sub/` | In `sub/` too — every level needs one |
+| **Test modules** | `ignition/script-python/pkg/__tests__/` | In both `pkg/` AND `__tests__/` |
+| **Perspective views** | `com.inductiveautomation.perspective/views/MyView/` | Next to `view.json` |
+| **Named queries** | `com.inductiveautomation.naming/queries/MyQuery/` | Next to `query.json` |
+| **Vision windows** | `com.inductiveautomation.vision/windows/MyWindow/` | Next to `window.json` |
+| **WebDev endpoints** | `com.inductiveautomation.webdev/resources/my-endpoint/` | Next to `doGet.py`, `config.json`, etc. |
+| **Alarm pipelines** | `com.inductiveautomation.alarm-notification/pipelines/` | Next to pipeline resource files |
+| **Tag configs** | `tags/` | Alongside tag JSON exports |
+
+**Template for script resources** (scope `A` = script module):
+```json
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["code.py"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+**Template for Perspective views** (scope `G` = general):
+```json
+{
+  "scope": "G",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["view.json", "thumbnail.png"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    },
+    "lastModificationSignature": "unknown"
+  }
+}
+```
+
+**Template for WebDev endpoints**:
+```json
+{
+  "scope": "G",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["config.json", "doGet.py", "doPost.py"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+**The `files` array must list every file in the directory that Ignition should load.** If you add a file but don't list it in `files`, Ignition ignores it.
+
+**When creating any new resource in an Ignition project: ALWAYS create the `resource.json` at the same time.** Never create a `code.py`, `view.json`, or any other Ignition resource file without its accompanying `resource.json`.
+
 ## Jython Conventions
 - Use `print()` function form (not `print x`)
 - Java classes are directly importable: `from java.util import ArrayList`

--- a/claude-code-plugin/skills/ignition-api/SKILL.md
+++ b/claude-code-plugin/skills/ignition-api/SKILL.md
@@ -86,14 +86,14 @@ This applies to ALL resource types:
 Ignition's script library (`ignition/script-python/`) has a strict structure. Each directory is either a **leaf module** or a **package node** — never both.
 
 **Leaf module** — has `code.py` with real code, NO child directories with code:
-```
+```text
 core/util/secrets/
 ├── code.py          ← actual functions live here
 └── resource.json
 ```
 
 **Package node** — has child directories, NO `code.py` (or only an empty placeholder):
-```
+```text
 core/util/
 ├── secrets/         ← child module
 │   ├── code.py
@@ -108,7 +108,7 @@ core/util/
 
 **Exception:** `__tests__/` directories are special — Ignition's script runtime ignores directories whose names start with `__`, so they do not conflict with a sibling `code.py`. The testing framework relies on this convention.
 
-```
+```text
 WRONG:
 my_package/
 ├── code.py          ← has real code

--- a/claude-code-plugin/skills/ignition-api/SKILL.md
+++ b/claude-code-plugin/skills/ignition-api/SKILL.md
@@ -143,6 +143,21 @@ When `resource.json` exists without `code.py`, Ignition recognizes the directory
 }
 ```
 
+## Linting
+
+This project uses [`ignition-lint`](https://pypi.org/project/ignition-lint-toolkit/) to catch Ignition-specific issues. The auto-lint hook runs on every file write, but you should also be aware of what it checks so you write clean code from the start:
+
+- **JYTHON_PRINT_STATEMENT** — Use `print()` function form, not `print x`
+- **JYTHON_IMPORT_STAR** — Never use `from module import *`
+- **IGNITION_UNKNOWN_SYSTEM_CALL** — Verify `system.*` function names are correct
+- **IGNITION_SYSTEM_OVERRIDE** — Never shadow `system.*` with local variables
+- **LONG_LINE** — Keep lines under 120 characters
+- **MISSING_DOCSTRING** — Add docstrings to public functions
+- **EXPR_NOW_DEFAULT_POLLING** — Expression `now()` defaults to 1-second polling; use `now(5000)` or higher
+- **EMPTY_COMPONENT_NAME / GENERIC_COMPONENT_NAME** — Perspective components need meaningful names
+
+If `ignition-lint` is installed, the plugin's auto-lint hook catches these automatically after every file edit. If it's not installed, the hook silently exits — nothing breaks, but you lose automatic feedback.
+
 ## Jython Conventions
 - Use `print()` function form (not `print x`)
 - Java classes are directly importable: `from java.util import ArrayList`

--- a/claude-code-plugin/skills/ignition-api/SKILL.md
+++ b/claude-code-plugin/skills/ignition-api/SKILL.md
@@ -81,6 +81,68 @@ This applies to ALL resource types:
 
 **When creating any new resource in an Ignition project: ALWAYS create the `resource.json` at the same time.** Never create a `code.py`, `view.json`, or any other Ignition resource file without its accompanying `resource.json`.
 
+## Ignition Script Library Structure
+
+Ignition's script library (`ignition/script-python/`) has a strict structure. Each directory is either a **leaf module** or a **package node** — never both.
+
+**Leaf module** — has `code.py` with real code, NO child directories with code:
+```
+core/util/secrets/
+├── code.py          ← actual functions live here
+└── resource.json
+```
+
+**Package node** — has child directories, NO `code.py` (or only an empty placeholder):
+```
+core/util/
+├── secrets/         ← child module
+│   ├── code.py
+│   └── resource.json
+├── csv/             ← child module
+│   ├── code.py
+│   └── resource.json
+└── resource.json    ← resource.json still required, but NO code.py
+```
+
+**NEVER put a `code.py` in a directory that also contains child packages.** Ignition treats a directory with `code.py` as a leaf module. If you also put subdirectories in it, the behavior is undefined and the child modules may not be importable.
+
+```
+WRONG:
+my_package/
+├── code.py          ← has real code
+├── resource.json
+└── __tests__/       ← child directory — conflicts with code.py above
+    ├── code.py
+    └── resource.json
+
+CORRECT:
+my_package/
+├── resource.json    ← package node, no code.py
+├── logic/
+│   ├── code.py      ← real code lives in a leaf
+│   └── resource.json
+└── __tests__/
+    ├── code.py      ← tests live in a leaf
+    └── resource.json
+```
+
+When `resource.json` exists without `code.py`, Ignition recognizes the directory as a package node. The `files` array in `resource.json` should be empty or omit `code.py`:
+```json
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": [],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
 ## Jython Conventions
 - Use `print()` function form (not `print x`)
 - Java classes are directly importable: `from java.util import ArrayList`

--- a/claude-code-plugin/skills/ignition-e2e/SKILL.md
+++ b/claude-code-plugin/skills/ignition-e2e/SKILL.md
@@ -1,0 +1,264 @@
+---
+description: Ignition Perspective e2e testing reference — Playwright page objects, gateway API helpers, and Perspective DOM conventions. Use when writing or debugging Playwright browser tests for Perspective views.
+user-invocable: false
+---
+
+# Ignition Perspective E2E Testing Reference
+
+This project uses Playwright to test Ignition Perspective views in a real browser. Tests run against a live gateway, authenticate through the Perspective login form, and interact with the actual Perspective SPA.
+
+## Architecture
+
+- **e2e/** directory at project root contains all Playwright tests
+- **PerspectivePage** — base page object that wraps Playwright's `Page` for Perspective conventions
+- **Component wrappers** — typed wrappers for Perspective components (Button, Table, etc.)
+- **gateway-api.ts** — Node.js helper that calls WebDev endpoints for tag read/write, script invocation
+- **Auth fixture** — authenticates once, persists session to `.auth/user.json` for reuse
+
+## Perspective DOM Conventions (CRITICAL)
+
+Perspective is a React SPA served over WebSocket. The DOM has specific conventions you MUST understand:
+
+### data-component-path
+
+Every Perspective component has `data-component-path` using **positional indices**, NOT the named paths from `view.json`.
+
+**Prefix convention:**
+- `L[n]` = left dock (e.g., `L[0]`, `L[1]`)
+- `T[n]` = top dock (e.g., `T[0]`)
+- `C` = center (page content)
+- `$` separates embedded view boundaries
+- `:` separates child indices
+
+**Examples:**
+- `C` — the root page content container
+- `C:0:1` — second child of first child of page content
+- `C:0$0:2` — embedded view boundary, then third child
+- `T[0]:0:1` — top dock, first container, second child
+- `L[0]` — left dock
+
+### data-component
+
+The component type attribute: `data-component="ia.display.label"`, `data-component="ia.input.button"`, etc.
+
+### Key rules
+
+1. **Never use `page.goto()` after initial session open** — it creates a new WebSocket session. Use `PerspectivePage.openPage(route)` instead.
+2. **Page content is scoped by `C` prefix** — use `perspective.pageContent()` to exclude docks.
+3. **Docks render independently** — top dock (`T[0]`) may be visible before page content (`C`).
+4. **Embedded views reset the path counter** — `$` marks the boundary, child indices restart from 0.
+5. **Left dock is often `onDemand`** — check `toBeAttached()` not `toBeVisible()`.
+
+## PerspectivePage (Base Page Object)
+
+```typescript
+import { PerspectivePage } from "../pages/PerspectivePage";
+
+// Available methods:
+perspective.openPage("/route")           // Open a page route (call once per test)
+perspective.waitForPageContent(timeout?)  // Wait for C-prefixed content to render
+perspective.waitForSession(timeout?)      // Wait for any [data-component] elements
+perspective.pageContent()                // Locator scoped to page content (excludes docks)
+perspective.componentByType("ia.display.label")  // Find by component type in page content
+perspective.pageLabelWithText("Title")   // Find label with text in page content
+perspective.pageText("some text")        // Find visible text in page content
+perspective.dismissPopups()              // Close popup overlays
+perspective.dumpComponentPaths()         // Debug: list all component paths in DOM
+```
+
+## Component Wrappers
+
+### PerspectiveComponent (base)
+```typescript
+const comp = new PerspectiveComponent(locator, page);
+await comp.isVisible(timeout?)      // Returns boolean
+await comp.waitForVisible(timeout?) // Throws if not visible
+await comp.getText()                // Text content
+```
+
+### Button (`ia.input.button`)
+```typescript
+const btn = new Button(locator, page);
+await btn.click()       // Wait for visible, then click
+await btn.isEnabled()   // Checks for "ia_button--disabled" class
+```
+
+### Table (`ia.display.table`)
+```typescript
+const table = new Table(locator, page);
+await table.waitForData(timeout?)       // Wait for first row to render
+await table.getRowCount()               // Number of visible rows
+await table.clickRow(index)             // Click row by index
+await table.getCellText(row, column)    // Get cell text content
+```
+
+Row selector: `.ia_table__body__row`
+Cell selector: `.ia_table__body__cell`
+
+## Gateway API Helper
+
+Call WebDev endpoints from test code:
+
+```typescript
+import { readTags, writeTags, readTag, writeTag, callScript, isGatewayReachable, mirrorTags, deleteMirror } from "../helpers/gateway-api";
+
+// Tag operations
+const values = await readTags(["[WHK01]Path/To/Tag1", "[WHK01]Path/To/Tag2"]);
+// Returns: { "[WHK01]Path/To/Tag1": { value: 42, quality: "Good", good: true } }
+
+const val = await readTag("[WHK01]Path/To/Tag");  // Single tag, returns value or null
+
+await writeTag("[default]Test/Tag", 42);           // Single write, returns boolean
+await writeTags([{ path: "[default]Test/Tag1", value: "hello" }, { path: "[default]Test/Tag2", value: 123 }]);
+
+// Script invocation — call real Jython scripts on the gateway
+const result = await callScript("core.mes.changeover.client.get_state", ["cooker"]);
+// Returns: { success: true, result: { current_state: "idle", ... } }
+
+// Tag mirroring — clone OPC tags to memory for testing without PLC
+await mirrorTags("[WHK01]Distillery01/Mashing01", "[WHK01]Distillery01/Mashing01_MEM");
+// ... run tests against memory tags ...
+await deleteMirror("[WHK01]Distillery01/Mashing01_MEM");  // Cleanup
+
+// Health check
+const reachable = await isGatewayReachable();  // Quick connectivity check
+```
+
+## Auth Setup
+
+The `fixtures/auth.setup.ts` handles authentication:
+1. Navigates to `/data/perspective/client/<PROJECT>`
+2. Polls for login form (`input.username-field`) or live session (`[data-component]`)
+3. If login form: fills credentials from `IGNITION_USER`/`IGNITION_PASSWORD` env vars
+4. Persists session to `.auth/user.json` for reuse across tests
+
+**If auth fails:** Run `cd e2e && npx playwright test --project=setup` to re-authenticate.
+
+## Custom Fixture
+
+Use the `perspective` fixture instead of raw `page`:
+
+```typescript
+import { test, expect } from "../fixtures/perspective";
+
+test("my test", async ({ perspective }) => {
+  await perspective.openPage("/my-page");
+  const title = perspective.pageLabelWithText("My Title");
+  await expect(title.first()).toBeVisible();
+});
+```
+
+This auto-wraps `page` in a `PerspectivePage` instance.
+
+## Writing Tests
+
+### Basic smoke test
+```typescript
+import { test, expect } from "../../fixtures/perspective";
+
+test.describe("My View smoke tests", () => {
+  test("page loads with expected title", async ({ perspective }) => {
+    await perspective.openPage("/my-view");
+    const title = perspective.pageLabelWithText("Expected Title");
+    await expect(title.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("table renders with data", async ({ perspective }) => {
+    await perspective.openPage("/my-view");
+    const table = perspective.componentByType("ia.display.table");
+    await expect(table.first()).toBeVisible();
+    // Check for data rows
+    await expect(table.locator(".ia_table__body__row").first()).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+### Integration test with tag setup
+```typescript
+import { test, expect } from "../../fixtures/perspective";
+import { writeTag, readTag, callScript } from "../../helpers/gateway-api";
+
+test.describe("Changeover integration", () => {
+  test.beforeAll(async () => {
+    // Set up test state via gateway API
+    await writeTag("[default]Test/State", "idle");
+  });
+
+  test.afterAll(async () => {
+    // Cleanup
+    await writeTag("[default]Test/State", "");
+  });
+
+  test("state change reflects in UI", async ({ perspective }) => {
+    await perspective.openPage("/changeover");
+    // Trigger state change via script
+    await callScript("core.mes.changeover.client.transition", ["cooker", "start"]);
+    // Verify UI updates
+    const label = perspective.pageText("running");
+    await expect(label).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+### Testing docks
+```typescript
+test("top dock shows plant data", async ({ perspective }) => {
+  // Don't use openPage for dock-only tests — just navigate to session root
+  await perspective.page.goto(`/data/perspective/client/${process.env.PERSPECTIVE_PROJECT}`);
+  await perspective.waitForSession();
+
+  const topDock = perspective.page.locator("[data-component-path^='T[0]']");
+  await expect(topDock.first()).toBeVisible();
+});
+
+test("left dock menu exists", async ({ perspective }) => {
+  await perspective.openPage("/some-page");
+  // Left dock is onDemand — check attached, not visible
+  const menu = perspective.page.locator("[data-component='ia.navigation.menutree']");
+  await expect(menu).toBeAttached({ timeout: 10_000 });
+});
+```
+
+## Running Tests
+
+```bash
+cd e2e
+
+# All tests
+npx playwright test
+
+# Specific area
+npx playwright test tests/changeover/
+
+# Smoke tests only
+npx playwright test tests/smoke/
+
+# Headed mode (see the browser)
+npx playwright test --headed
+
+# Single test file
+npx playwright test tests/smoke/perspective-loads.spec.ts
+
+# View HTML report after failures
+npx playwright show-report
+```
+
+## Environment Variables
+
+Set in `e2e/.env`:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `IGNITION_URL` | Gateway base URL | `https://localhost:9043` |
+| `IGNITION_USER` | Login username | `admin` |
+| `IGNITION_PASSWORD` | Login password | `password` |
+| `PERSPECTIVE_PROJECT` | Perspective project name | `QSI_WhiskeyHouseKentucky01` |
+| `TAG_PROVIDER` | Default tag provider | `WHK01` |
+
+## Common Pitfalls
+
+1. **Perspective takes 30-45s to reload after a project scan.** The auth fixture has a 45s timeout for this reason. If tests fail immediately after a scan, wait and retry.
+2. **Don't call `page.goto()` mid-test.** This kills the WebSocket session. Navigate within Perspective using component interactions or `openPage()` for the initial load.
+3. **Embedded views load asynchronously.** Wait for specific content inside them, don't rely on the parent container being visible.
+4. **Tables render headers before data.** Use `table.waitForData()` or wait for `.ia_table__body__row` specifically.
+5. **Popups from startup scripts** can block interaction. Call `perspective.dismissPopups()` after `openPage()` if needed.

--- a/claude-code-plugin/skills/ignition-e2e/SKILL.md
+++ b/claude-code-plugin/skills/ignition-e2e/SKILL.md
@@ -43,7 +43,7 @@ The component type attribute: `data-component="ia.display.label"`, `data-compone
 
 ### Key rules
 
-1. **Never use `page.goto()` after initial session open** — it creates a new WebSocket session. Use `PerspectivePage.openPage(route)` instead.
+1. **Never use `page.goto()` after initial session open** — it creates a new WebSocket session. Use `PerspectivePage.openPage(route)` instead. Exception: the very first navigation to the session root (e.g., for dock-only tests) may use `page.goto()`.
 2. **Page content is scoped by `C` prefix** — use `perspective.pageContent()` to exclude docks.
 3. **Docks render independently** — top dock (`T[0]`) may be visible before page content (`C`).
 4. **Embedded views reset the path counter** — `$` marks the boundary, child indices restart from 0.

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -199,6 +199,40 @@ ignition/script-python/core/mes/changeover/__tests__/code.py
 → module path: core.mes.changeover.__tests__
 ```
 
+## CRITICAL: resource.json Required for Every Package
+
+**Every directory** in `ignition/script-python/` MUST have a `resource.json` alongside `code.py`. Without it, Ignition does not load the module and imports will fail with `No module named ...`.
+
+When creating a new test module, you must create `resource.json` for BOTH the package directory AND the `__tests__` directory:
+
+```
+ignition/script-python/my_package/
+├── code.py           # Package code
+├── resource.json     # ← REQUIRED
+└── __tests__/
+    ├── code.py       # Test code
+    └── resource.json # ← REQUIRED
+```
+
+The `resource.json` content is always the same:
+```json
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["code.py"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+**If a test module import fails with `No module named ...`**, the first thing to check is whether `resource.json` exists in every directory in the module path. This is the most common cause of "module not found" errors in Ignition projects managed via git.
+
 ## Project Inheritance
 
 In projects that inherit from a parent:

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -199,39 +199,22 @@ ignition/script-python/core/mes/changeover/__tests__/code.py
 → module path: core.mes.changeover.__tests__
 ```
 
-## CRITICAL: resource.json Required for Every Package
+## CRITICAL: resource.json Required for Test Modules
 
-**Every directory** in `ignition/script-python/` MUST have a `resource.json` alongside `code.py`. Without it, Ignition does not load the module and imports will fail with `No module named ...`.
+**Every directory** in `ignition/script-python/` MUST have a `resource.json` alongside `code.py` — see the full `resource.json` reference in the `ignition-api` skill. Without it, Ignition silently ignores the module and imports fail with `No module named ...`.
 
-When creating a new test module, you must create `resource.json` for BOTH the package directory AND the `__tests__` directory:
+When creating a new test module, create `resource.json` for BOTH the package AND `__tests__`:
 
 ```
 ignition/script-python/my_package/
 ├── code.py           # Package code
-├── resource.json     # ← REQUIRED
+├── resource.json     # ← REQUIRED — use scope "A" template
 └── __tests__/
     ├── code.py       # Test code
-    └── resource.json # ← REQUIRED
+    └── resource.json # ← REQUIRED — use scope "A" template
 ```
 
-The `resource.json` content is always the same:
-```json
-{
-  "scope": "A",
-  "version": 1,
-  "restricted": false,
-  "overridable": true,
-  "files": ["code.py"],
-  "attributes": {
-    "lastModification": {
-      "actor": "external",
-      "timestamp": "2026-01-01T00:00:00Z"
-    }
-  }
-}
-```
-
-**If a test module import fails with `No module named ...`**, the first thing to check is whether `resource.json` exists in every directory in the module path. This is the most common cause of "module not found" errors in Ignition projects managed via git.
+**If a test module import fails with `No module named ...`**, check `resource.json` exists in every directory in the module path first. This is the #1 cause of test discovery failures.
 
 ## Project Inheritance
 

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -1,0 +1,238 @@
+---
+description: Ignition testing framework reference — writing and running Jython gateway tests. Use when writing tests, debugging test failures, or working with the testing.* modules.
+user-invocable: false
+---
+
+# Ignition Testing Framework Reference
+
+This project uses a custom Jython test framework that runs on the Ignition gateway. Tests execute in the gateway's script context with full access to `system.*` APIs, real tags, and database connections.
+
+## Architecture
+
+- **Test scripts** live in `ignition/script-python/` as `__tests__/code.py` inside any package
+- **Test framework** (`testing.*` modules) may live in this project or be inherited from a parent project
+- **WebDev endpoints** (`testing/run`, `testing/tags`) are always project-scoped — each project has its own
+- **Test runner** discovers `__tests__/code.py` files by walking the filesystem, imports them, and executes `@test`-decorated functions
+
+## Writing Tests
+
+Create `ignition/script-python/<package>/__tests__/code.py` with a matching `resource.json`:
+
+```python
+from testing.decorators import test, skip, setup, teardown, expected_error
+from testing.assertions import assert_equal, assert_true, assert_not_none, assert_raises
+
+@setup
+def setup_module():
+    """Runs once before all tests in this module."""
+    pass
+
+@teardown
+def teardown_module():
+    """Runs once after all tests in this module."""
+    pass
+
+@test
+def test_basic_logic():
+    result = 2 + 2
+    assert_equal(result, 4, "basic math works")
+
+@test
+def test_tag_value():
+    from testing.assertions import assert_tag_value
+    assert_tag_value("[WHK01]Path/To/Tag", expected_value)
+
+@test
+def test_system_call():
+    result = system.tag.readBlocking(["[default]Some/Tag"])[0]
+    assert_not_none(result.value, "tag should have a value")
+    assert_true(result.quality.isGood(), "tag quality should be good")
+
+@skip("waiting on PLC config")
+@test
+def test_not_ready_yet():
+    pass
+
+@expected_error(ValueError)
+@test
+def test_bad_input():
+    int("not a number")
+```
+
+The `resource.json` alongside `code.py`:
+```json
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["code.py"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+## testing.decorators
+
+| Decorator | Purpose |
+|-----------|---------|
+| `@test` | Marks a function as a test case. Runner discovers functions with `_is_test = True`. |
+| `@skip(reason="")` | Skips the test. Apply BEFORE `@test`: `@skip("reason") @test def ...` |
+| `@setup` | Module-level setup — runs once before all tests. Only one per module. |
+| `@teardown` | Module-level teardown — runs once after all tests. Only one per module. |
+| `@expected_error(ExceptionType)` | Test passes if the given exception is raised, fails otherwise. |
+
+## testing.assertions
+
+| Function | Purpose |
+|----------|---------|
+| `assert_equal(actual, expected, msg=None)` | `actual == expected` |
+| `assert_not_equal(actual, expected, msg=None)` | `actual != expected` |
+| `assert_true(val, msg=None)` | `val` is truthy |
+| `assert_false(val, msg=None)` | `val` is falsy |
+| `assert_none(val, msg=None)` | `val is None` |
+| `assert_not_none(val, msg=None)` | `val is not None` |
+| `assert_close(actual, expected, tolerance=0.001, msg=None)` | Floating point comparison within tolerance |
+| `assert_raises(callable_fn, exception_type, msg=None)` | `callable_fn()` raises `exception_type`. Returns the caught exception. |
+| `assert_tag_value(tag_path, expected, msg=None)` | Reads a real gateway tag and asserts its value. Uses `system.tag.readBlocking`. |
+| `assert_contains(container, item, msg=None)` | `item in container` |
+| `assert_isinstance(obj, expected_type, msg=None)` | `isinstance(obj, expected_type)` |
+
+All raise `TestAssertionError` (subclass of `AssertionError`) with `actual` and `expected` attributes for structured reporting.
+
+## testing.helpers
+
+| Function | Purpose |
+|----------|---------|
+| `write_dataset_tag(tag_path, columns, types, rows)` | Create a real Ignition `DataSet` via `system.dataset.toDataSet()` and write to tag. Auto-reconfigures tag type if needed. Types: `String`, `Float8`, `Int4`, `Boolean`, `DateTime`. |
+| `clear_dataset_tag(tag_path, columns, types)` | Write an empty DataSet to a tag (cleanup). |
+
+## testing.runner
+
+| Function | Purpose |
+|----------|---------|
+| `run_all(base_package="")` | Discover and run all `__tests__` modules. Optional `base_package` filter (e.g., `"core.mes"`). |
+| `run_module(module_path)` | Run a specific module (e.g., `"core.mes.changeover.__tests__"`). |
+
+Returns structured dict:
+```python
+{
+    "passed": int, "failed": int, "skipped": int, "errors": int,
+    "total": int, "duration_ms": int,
+    "modules": [{"module": "...", "results": [{"name": "...", "status": "passed|failed|skipped|error", "message": "...", "duration_ms": int}]}]
+}
+```
+
+## testing.reporter
+
+| Function | Purpose |
+|----------|---------|
+| `to_json(results)` | JSON string |
+| `to_console(results)` | Human-readable text for Script Console |
+| `to_junit_xml(results)` | JUnit XML for CI integration |
+
+## Running Tests
+
+**From Script Console:**
+```python
+print testing.runner.run_all()
+print testing.runner.run_module("core.mes.changeover.__tests__")
+print testing.reporter.to_console(testing.runner.run_all())
+```
+
+**Via HTTP (WebDev endpoints):**
+```bash
+# Discover modules
+curl -k -s "https://localhost:9043/system/webdev/<PROJECT>/testing/run?discover=true"
+
+# Run all
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/run"
+
+# Run specific module
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/run?module=core.mes.changeover.__tests__"
+
+# Run by package prefix
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/run?package=core.mes"
+
+# Output formats: json (default), junit, text
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/run?format=text"
+```
+
+**HTTP response codes:** 200 = all passed, 207 = failures/errors, 500 = runner error.
+
+## testing/tags Endpoint
+
+Read/write tags from E2E tests or external tools:
+
+```bash
+# Read tags
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"reads": ["[WHK01]Path/To/Tag"]}'
+
+# Write tags (auto-creates if missing)
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"writes": [{"path": "[default]Test/Tag", "value": 42}]}'
+
+# Call a gateway script function
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"script": {"path": "core.util.secrets.get_secret", "args": ["mes-host"]}}'
+
+# Delete tags (cleanup)
+curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"deleteTags": "[default]Test/Tag"}'
+```
+
+## Test Discovery Convention
+
+The runner walks `ignition/script-python/` looking for directories named `__tests__` or `__TESTS__` containing `code.py`. The dotted module path is derived from the filesystem path:
+
+```
+ignition/script-python/core/mes/changeover/__tests__/code.py
+→ module path: core.mes.changeover.__tests__
+```
+
+## Project Inheritance
+
+In projects that inherit from a parent:
+- **Test framework** (`testing.*`) — inherited automatically, lives in parent only
+- **Test modules** (`__tests__/code.py`) — can exist in both parent and child; runner discovers all
+- **WebDev endpoints** — NOT inherited, each project needs its own `testing/run` and `testing/tags`
+
+## Common Patterns
+
+**Testing a script function that reads tags:**
+```python
+@test
+def test_get_area_state():
+    from core.mes.changeover import client
+    result = client.get_state("cooker")
+    assert_not_none(result, "should return state dict")
+    assert_contains(result, "current_state")
+```
+
+**Testing with tag setup/teardown:**
+```python
+@setup
+def setup_module():
+    from testing.helpers import write_dataset_tag
+    write_dataset_tag("[default]Test/Queue", ["Id", "Value"], ["String", "Int4"], [["A", 1], ["B", 2]])
+
+@teardown
+def teardown_module():
+    from testing.helpers import clear_dataset_tag
+    clear_dataset_tag("[default]Test/Queue", ["Id", "Value"], ["String", "Int4"])
+
+@test
+def test_queue_processing():
+    qv = system.tag.readBlocking(["[default]Test/Queue"])[0]
+    ds = qv.value
+    assert_equal(ds.getRowCount(), 2)
+```

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -16,6 +16,27 @@ This project uses a custom Jython test framework that runs on the Ignition gatew
 
 ## Writing Tests
 
+### File placement convention (IMPORTANT)
+
+Tests go **inside the package they test** as a `__tests__` subdirectory. **Never create standalone top-level test packages.**
+
+```
+CORRECT — tests live inside the package:
+ignition/script-python/core/util/__tests__/code.py          → tests core.util
+ignition/script-python/core/mes/changeover/__tests__/code.py → tests core.mes.changeover
+ignition/script-python/core/networking/__tests__/code.py     → tests core.networking
+
+WRONG — never do this:
+ignition/script-python/testing_smoke/__tests__/code.py       → standalone test package with no matching code
+ignition/script-python/tests/__tests__/code.py               → standalone tests directory
+```
+
+The runner discovers modules by path: `core.mes.changeover.__tests__`. This naming makes it obvious what each test module covers.
+
+If you need a smoke test that tests the framework itself (not any specific package), put it in an existing utility package like `core/util/__tests__/` or ask the user which package it should live in.
+
+### Test file structure
+
 Create `ignition/script-python/<package>/__tests__/code.py` with a matching `resource.json`:
 
 ```python

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -20,7 +20,7 @@ This project uses a custom Jython test framework that runs on the Ignition gatew
 
 Tests go **inside the package they test** as a `__tests__` subdirectory. **Never create standalone top-level test packages.**
 
-```
+```text
 CORRECT — tests live inside the package:
 ignition/script-python/core/util/__tests__/code.py          → tests core.util
 ignition/script-python/core/mes/changeover/__tests__/code.py → tests core.mes.changeover
@@ -61,7 +61,7 @@ def test_basic_logic():
 @test
 def test_tag_value():
     from testing.assertions import assert_tag_value
-    assert_tag_value("[WHK01]Path/To/Tag", expected_value)
+    assert_tag_value("[default]Path/To/Tag", 42.0)
 
 @test
 def test_system_call():
@@ -215,7 +215,7 @@ curl -k -s -X POST "https://localhost:9043/system/webdev/<PROJECT>/testing/tags"
 
 The runner walks `ignition/script-python/` looking for directories named `__tests__` or `__TESTS__` containing `code.py`. The dotted module path is derived from the filesystem path:
 
-```
+```text
 ignition/script-python/core/mes/changeover/__tests__/code.py
 → module path: core.mes.changeover.__tests__
 ```
@@ -226,7 +226,7 @@ ignition/script-python/core/mes/changeover/__tests__/code.py
 
 When creating a new test module, create `resource.json` for BOTH the package AND `__tests__`:
 
-```
+```text
 ignition/script-python/my_package/
 ├── code.py           # Package code
 ├── resource.json     # ← REQUIRED — use scope "A" template

--- a/claude-code-plugin/skills/ignition-testing/SKILL.md
+++ b/claude-code-plugin/skills/ignition-testing/SKILL.md
@@ -206,6 +206,23 @@ In projects that inherit from a parent:
 - **Test modules** (`__tests__/code.py`) — can exist in both parent and child; runner discovers all
 - **WebDev endpoints** — NOT inherited, each project needs its own `testing/run` and `testing/tags`
 
+### Runner discovery and child project tests
+
+The test runner discovers `__tests__` modules by walking the gateway filesystem. The **scaffolded runner** (from this plugin) dynamically scans all projects in the gateway's data directory, so it finds tests in both parent and child projects automatically.
+
+**However**, if the parent project has an **older runner** (pre-scaffold, hardcoded paths), it will only find tests in its own project. Child project tests won't be discovered.
+
+**When a user adds tests to a child project and they aren't discovered, ASK THE USER:**
+
+> "The test runner in your parent project (*{parent_name}*) only scans its own script library. Your child project's `__tests__` modules won't be discovered. Two options:
+>
+> 1. **Update the parent runner** — Replace `testing/runner/code.py` in *{parent_name}* with the updated version that dynamically discovers all projects. This fixes it for every child project.
+> 2. **Override the runner in this project** — Create `testing/runner/code.py` here with dynamic discovery. This project gets its own runner without touching the parent.
+>
+> Which do you prefer?"
+
+If they choose option 2, scaffold the runner locally (don't use `--skip-scripts`, or copy just the runner module). If they choose option 1, update the parent's runner code.
+
 ## Common Patterns
 
 **Testing a script function that reads tags:**

--- a/claude-code-plugin/skills/init-e2e/SKILL.md
+++ b/claude-code-plugin/skills/init-e2e/SKILL.md
@@ -54,9 +54,16 @@ Scaffold a complete Playwright e2e test setup for Perspective views. This create
    cd <project-root>/e2e && npm install && npx playwright install chromium
    ```
 
-9. Tell the user to set up credentials:
-   - Copy `e2e/.env.example` to `e2e/.env`
-   - Fill in `IGNITION_USER` and `IGNITION_PASSWORD`
+9. Set up the `.env` file:
+   - Check detection output for `parent.has_e2e_env`. If the parent project has an existing `e2e/.env`:
+     - Tell the user: "Your parent project *{parent.name}* already has an `e2e/.env` at `{parent.e2e_env_path}`. Since both projects share the same gateway, I can copy it and just update the `PERSPECTIVE_PROJECT` name."
+     - Copy the parent's `.env` to `<project-root>/e2e/.env`
+     - Update `PERSPECTIVE_PROJECT` to the confirmed value for this project
+     - Show the user what was set and ask them to verify credentials are still correct
+   - If no parent `.env` exists:
+     - Copy `e2e/.env.example` to `e2e/.env`
+     - Tell the user to fill in `IGNITION_USER` and `IGNITION_PASSWORD`
+   - **Never commit `.env`** — it's in the scaffolded `.gitignore`
 
 10. Explain auth setup:
     - Run `cd e2e && npx playwright test --project=setup` to authenticate

--- a/claude-code-plugin/skills/init-e2e/SKILL.md
+++ b/claude-code-plugin/skills/init-e2e/SKILL.md
@@ -1,0 +1,64 @@
+---
+description: Scaffold Playwright e2e tests for Perspective views into an Ignition project. Usage — /ignition-scada:init-e2e [--force]
+---
+
+# Initialize E2E Tests
+
+Scaffold a complete Playwright e2e test setup for Perspective views. This creates:
+- **e2e/** directory with Playwright config, auth fixtures, and TypeScript setup
+- **Page objects** for Perspective views (PerspectivePage base class)
+- **Component wrappers** (Button, Table, PerspectiveComponent)
+- **Gateway API helper** for tag read/write, script invocation, and health checks
+- **Smoke tests** that verify session loading and basic rendering
+
+## Steps
+
+1. Run the detection script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Check `has_perspective` — if false, warn the user: "No Perspective module found (`com.inductiveautomation.perspective/` directory missing). E2E tests require Perspective views. Continue anyway?"
+
+3. Present findings and ask the user to confirm their tag provider.
+
+4. Auto-detect the Perspective project name:
+   - If the gateway is reachable, the Perspective project name is typically the Ignition project name
+   - Check environment for `PERSPECTIVE_PROJECT` variable
+   - Ask the user to confirm the Perspective project name
+
+5. Ask the user to confirm the Perspective project name.
+
+6. Check if the Jython test framework exists (`existing_testing.jython_framework`). If not, inform the user and automatically run the testing scaffold first:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-testing.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed>
+   ```
+   The e2e gateway-api helper depends on the WebDev `testing/tags` endpoint.
+
+7. Run the e2e scaffold script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-e2e.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed> \
+     --perspective-project <confirmed>
+   ```
+
+8. Install dependencies:
+   ```bash
+   cd <project-root>/e2e && npm install && npx playwright install chromium
+   ```
+
+9. Tell the user to set up credentials:
+   - Copy `e2e/.env.example` to `e2e/.env`
+   - Fill in `IGNITION_USER` and `IGNITION_PASSWORD`
+
+10. Explain auth setup:
+    - Run `cd e2e && npx playwright test --project=setup` to authenticate
+    - Run `npm test` to run the smoke tests
+    - Run `npx playwright show-report` to view results in a browser

--- a/claude-code-plugin/skills/init-testing/SKILL.md
+++ b/claude-code-plugin/skills/init-testing/SKILL.md
@@ -21,12 +21,18 @@ Scaffold a complete Jython test framework into the current Ignition project. Thi
    - Gateway URL and reachability
    - Tag providers (if detected)
    - Any existing test infrastructure
+   - **Parent project** (if this project inherits from another)
 
 3. Ask the user to confirm or provide their tag provider name.
 
-4. If `existing_testing.jython_framework` or `existing_testing.webdev_endpoints` is true, warn the user and ask if they want to overwrite (`--force`).
+4. **Check for project inheritance.** If `parent` is not null:
+   - Tell the user: "This project inherits from *{parent.name}*."
+   - If `parent.has_jython_framework` is true: "The parent project already has the Jython test framework — your project inherits `testing.*` scripts automatically. I'll skip scaffolding scripts and only create the WebDev endpoints and type stubs."
+   - If parent not found on disk (`parent.root` is null): ask the user for the parent project path, or offer to scaffold everything locally.
 
-5. Run the scaffold script:
+5. If `existing_testing.jython_framework` or `existing_testing.webdev_endpoints` is true, warn the user and ask if they want to overwrite (`--force`).
+
+6. Run the scaffold script:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-testing.sh \
      --project-root <detected> \
@@ -34,6 +40,7 @@ Scaffold a complete Jython test framework into the current Ignition project. Thi
      --gateway-url <detected> \
      --tag-provider <confirmed>
    ```
+   Add `--skip-scripts` if the parent already has the Jython framework.
    Add `--force` if user confirmed overwrite.
 
 6. Report what was created (list the files).

--- a/claude-code-plugin/skills/init-testing/SKILL.md
+++ b/claude-code-plugin/skills/init-testing/SKILL.md
@@ -51,15 +51,15 @@ Scaffold a complete Jython test framework into the current Ignition project. Thi
    Add `--skip-scripts` if the parent already has the Jython framework.
    Add `--force` if user confirmed overwrite.
 
-6. Report what was created (list the files).
+7. Report what was created (list the files).
 
-7. If the gateway is reachable, verify the setup by hitting the test discovery endpoint:
+8. If the gateway is reachable, verify the setup by hitting the test discovery endpoint:
    ```bash
    curl -k -s "<gateway>/system/webdev/<project>/testing/run?discover=true"
    ```
    Note: This requires a gateway project scan first. Tell the user to scan from Designer or commit + push if using ignition-git-module.
 
-8. Explain how to write a first test:
+9. Explain how to write a first test:
    - Create `ignition/script-python/<package>/__tests__/code.py`
    - Import `from testing.decorators import test` and `from testing.assertions import assert_equal`
    - Write `@test` decorated functions

--- a/claude-code-plugin/skills/init-testing/SKILL.md
+++ b/claude-code-plugin/skills/init-testing/SKILL.md
@@ -1,0 +1,53 @@
+---
+description: Scaffold the Jython test framework, WebDev test endpoints, and type stubs into an Ignition project. Usage — /ignition-scada:init-testing [--all] [--force]
+---
+
+# Initialize Ignition Testing
+
+Scaffold a complete Jython test framework into the current Ignition project. This creates:
+- **testing/** script library (runner, assertions, decorators, helpers, reporter)
+- **WebDev endpoints** for running tests and manipulating tags (`testing/run`, `testing/tags`)
+- **Type stubs** for IDE completion (`.ignition-stubs/testing/`)
+
+## Steps
+
+1. Run the detection script to discover project context:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Parse the JSON output and present findings to the user:
+   - Project name and location
+   - Gateway URL and reachability
+   - Tag providers (if detected)
+   - Any existing test infrastructure
+
+3. Ask the user to confirm or provide their tag provider name.
+
+4. If `existing_testing.jython_framework` or `existing_testing.webdev_endpoints` is true, warn the user and ask if they want to overwrite (`--force`).
+
+5. Run the scaffold script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-testing.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed>
+   ```
+   Add `--force` if user confirmed overwrite.
+
+6. Report what was created (list the files).
+
+7. If the gateway is reachable, verify the setup by hitting the test discovery endpoint:
+   ```bash
+   curl -k -s "<gateway>/system/webdev/<project>/testing/run?discover=true"
+   ```
+   Note: This requires a gateway project scan first. Tell the user to scan from Designer or commit + push if using ignition-git-module.
+
+8. Explain how to write a first test:
+   - Create `ignition/script-python/<package>/__tests__/code.py`
+   - Import `from testing.decorators import test` and `from testing.assertions import assert_equal`
+   - Write `@test` decorated functions
+   - Run from Script Console: `print testing.runner.run_all()`
+
+If `$ARGUMENTS` contains `--all` and the project has Perspective (`has_perspective` is true), automatically proceed to run the `/ignition-scada:init-e2e` flow after completing the testing setup.

--- a/claude-code-plugin/skills/init-testing/SKILL.md
+++ b/claude-code-plugin/skills/init-testing/SKILL.md
@@ -27,7 +27,15 @@ Scaffold a complete Jython test framework into the current Ignition project. Thi
 
 4. **Check for project inheritance.** If `parent` is not null:
    - Tell the user: "This project inherits from *{parent.name}*."
-   - If `parent.has_jython_framework` is true: "The parent project already has the Jython test framework — your project inherits `testing.*` scripts automatically. I'll skip scaffolding scripts and only create the WebDev endpoints and type stubs."
+   - If `parent.has_jython_framework` is true, explain clearly what this means:
+
+     > **Inherited from parent (NOT created here):**
+     > The Jython test framework — `testing.runner`, `testing.assertions`, `testing.decorators`, `testing.helpers`, `testing.reporter` — lives in *{parent.name}* and is inherited automatically. These scripts are shared across all child projects. Any `__tests__` modules you write in this project will be discovered alongside the parent's tests.
+     >
+     > **Created here (project-scoped, NOT inherited in Ignition):**
+     > - **WebDev endpoints** (`testing/run`, `testing/tags`) — HTTP APIs are project-scoped in Ignition. Each project needs its own endpoints even if the scripts behind them are inherited. Without these, there's no HTTP entry point to run tests against this project.
+     > - **Type stubs** (`.ignition-stubs/testing/`) — IDE completions for the inherited test framework. These are local files, not Ignition resources.
+
    - If parent not found on disk (`parent.root` is null): ask the user for the parent project path, or offer to scaffold everything locally.
 
 5. If `existing_testing.jython_framework` or `existing_testing.webdev_endpoints` is true, warn the user and ask if they want to overwrite (`--force`).

--- a/claude-code-plugin/skills/test/SKILL.md
+++ b/claude-code-plugin/skills/test/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: Run Jython gateway tests or Playwright e2e tests. Usage — /ignition-scada:test [module|package|ui|e2e|smoke]
+---
+
+# Run Tests
+
+Run tests for the current Ignition project. Routes to gateway tests (Jython) or browser tests (Playwright) based on arguments.
+
+## Arguments
+
+`$ARGUMENTS`
+
+## Routing
+
+| Argument | Action |
+|----------|--------|
+| *(empty)* | Run all gateway Jython tests |
+| `<short-name>` (e.g. `changeover`) | Translate to module path and run: try `<name>.__tests__` first, search for matching module |
+| `<dotted.path>` (contains `.`) | Run as module or package filter |
+| `ui` or `e2e` | Run all Playwright tests |
+| `ui <area>` | Run Playwright tests in `e2e/tests/<area>/` |
+| `smoke` | Run `e2e/tests/smoke/` |
+
+## Gateway Tests
+
+1. Detect the project using the detect-project script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Check that test infrastructure exists (`existing_testing.jython_framework` and `existing_testing.webdev_endpoints`). If not, tell the user: "Test infrastructure not found. Run `/ignition-scada:init-testing` first."
+
+3. Trigger a gateway project scan (if API token is available):
+   ```bash
+   TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
+   if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
+     TOKEN=$(cat "$TOKEN_FILE")
+     curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+       "<gateway>/data/project-scan-endpoint/scan?updateDesigners=true"
+   fi
+   ```
+
+4. Wait 3-5 seconds for scan propagation.
+
+5. Run the tests:
+   ```bash
+   # All tests
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run"
+
+   # Specific module
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run?module=<module>"
+
+   # Package filter
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run?package=<package>"
+   ```
+
+6. Parse the JSON response and present results:
+   - Summary: total, passed, failed, skipped, errors, duration
+   - On failure: show each failure with test name, error message, and traceback
+   - On success: report concisely
+
+## Playwright Tests
+
+1. Check that `e2e/node_modules` exists. If not, tell the user to run `cd e2e && npm install && npx playwright install chromium`.
+
+2. Check that `e2e/.auth/user.json` exists. If not, tell the user to run `cd e2e && npx playwright test --project=setup`.
+
+3. Run the tests:
+   ```bash
+   # All e2e tests
+   cd e2e && npx playwright test
+
+   # Specific area
+   cd e2e && npx playwright test tests/<area>/
+
+   # Smoke only
+   cd e2e && npx playwright test tests/smoke/
+
+   # Add --headed if the user says "headed" or "watch"
+   ```
+
+4. Parse the output and report results.
+
+5. On failure, suggest: `cd e2e && npx playwright show-report`

--- a/claude-code-plugin/skills/test/SKILL.md
+++ b/claude-code-plugin/skills/test/SKILL.md
@@ -12,14 +12,19 @@ Run tests for the current Ignition project. Routes to gateway tests (Jython) or 
 
 ## Routing
 
+**Default is always gateway (Jython) tests.** Only route to Playwright when explicitly asked with `ui` or `e2e`.
+
 | Argument | Action |
 |----------|--------|
 | *(empty)* | Run all gateway Jython tests |
-| `<short-name>` (e.g. `changeover`) | Translate to module path and run: try `<name>.__tests__` first, search for matching module |
-| `<dotted.path>` (contains `.`) | Run as module or package filter |
-| `ui` or `e2e` | Run all Playwright tests |
+| `<short-name>` (e.g. `changeover`) | Translate to module path and run gateway test: try `<name>.__tests__` first, search for matching module |
+| `<dotted.path>` (contains `.`) | Run as gateway module or package filter |
+| `ui` or `e2e` | Run all Playwright browser tests |
 | `ui <area>` | Run Playwright tests in `e2e/tests/<area>/` |
-| `smoke` | Run `e2e/tests/smoke/` |
+| `ui smoke` | Run Playwright smoke tests (`e2e/tests/smoke/`) |
+| `smoke` | Run gateway Jython tests — NOT Playwright. "Smoke test" without `ui` prefix means gateway tests. |
+
+**Ambiguity rule:** If the user says "smoke test", "run tests", "test it", or any unqualified test request — **always default to gateway Jython tests**, not Playwright. Only use Playwright when the user explicitly says "ui", "e2e", "browser", or "playwright".
 
 ## Gateway Tests
 

--- a/docs/claude-code-plugin/overview.md
+++ b/docs/claude-code-plugin/overview.md
@@ -1,0 +1,119 @@
+---
+sidebar_position: 1
+---
+
+# Claude Code Plugin
+
+A Claude Code plugin that gives Claude full domain awareness when working on Ignition SCADA projects. Claude automatically understands the `system.*` API, the expression language, project structure conventions, and how to scaffold and run tests — without you having to explain any of it.
+
+## What It Does
+
+The plugin provides 8 skills (4 Claude-only background knowledge, 4 user-invocable commands) plus auto-linting and auto-testing hooks.
+
+| Feature | Description |
+|---------|-------------|
+| **Auto-lint hook** | Runs `ignition-lint` after every Write/Edit on `.py`, `view.json`, and `tags.json` files. Diagnostics feed back to Claude, which fixes issues immediately. |
+| **API reference** | Claude knows every `system.*` function — completions, conventions, anti-patterns — without you explaining the API. |
+| **Expression language** | Claude understands Ignition's expression syntax (NOT Python) and all 104 built-in functions. |
+| **Manual lint** | `/ignition-scada:ignition-lint` — lint specific files or the whole project on demand. |
+| **Test scaffolding** | `/ignition-scada:init-testing` scaffolds a Jython test framework. `/ignition-scada:init-e2e` adds Playwright browser tests. |
+| **Test runner** | `/ignition-scada:test` runs gateway Jython tests or Playwright browser tests with smart routing. |
+| **Auto-test hooks** | After `git commit`, runs gateway tests. After editing a `view.json`, runs scoped Playwright tests. |
+
+## Install
+
+```bash
+claude plugin add --from whiskeyhouse/ignition-nvim --path claude-code-plugin
+```
+
+Or from a local clone:
+
+```bash
+claude plugin add --from /path/to/ignition-nvim/claude-code-plugin
+```
+
+## Prerequisites
+
+The auto-lint hook requires [`ignition-lint`](https://pypi.org/project/ignition-lint-toolkit/):
+
+```bash
+pip install ignition-lint-toolkit
+```
+
+If `ignition-lint` is not installed, the hook silently exits — nothing breaks.
+
+The detection scripts also require `jq` for JSON parsing (pre-installed on most systems).
+
+## How Auto-Linting Works
+
+After every Write or Edit, the hook checks if the file is inside an Ignition project (walks up from the file looking for `project.json`). If it is:
+
+- `.py` files are linted with the `scripts-only` profile
+- `view.json` files are linted with the `perspective-only` profile
+- `tags.json` files are linted with the `full` profile
+
+Any issues are returned as structured JSON, which Claude reads and acts on — typically fixing the issue in its next edit.
+
+Files outside Ignition projects are ignored. The hook is safe for global install.
+
+## Claude-Only Skills
+
+Four skills provide background knowledge that Claude draws on automatically. They never appear in the `/` menu — they are loaded when relevant.
+
+### ignition-api
+
+Gives Claude complete knowledge of Ignition's scripting API:
+- All 14 `system.*` modules (239 functions) with signatures and conventions
+- Jython 2.7 rules (no f-strings, no type hints, `print()` function form)
+- `resource.json` structure — every file in an Ignition project needs one
+- Script library structure (leaf modules vs package nodes)
+- Common patterns and anti-patterns
+
+### ignition-expressions
+
+Teaches Claude the Ignition expression language:
+- All 104 built-in functions across 10 categories (math, string, date/time, logic, type casting, dataset, JSON, tag quality, color, advanced)
+- Property reference syntax (`{this.props.value}`, `{view.custom.x}`)
+- Key rules like `now()` polling rates and `runScript()` syntax
+
+### ignition-testing
+
+Provides the complete Jython test framework reference:
+- `testing.*` modules (runner, assertions, decorators, helpers, reporter)
+- Test discovery conventions (`__tests__/code.py` inside each package)
+- WebDev endpoint API (`testing/run`, `testing/tags`)
+- Project inheritance rules
+
+### ignition-e2e
+
+Teaches Claude how Perspective works in the browser:
+- Perspective DOM conventions (`data-component-path`, `data-component`)
+- PerspectivePage page object and component wrappers
+- Gateway API helper for tag operations from test code
+- Auth setup and session persistence
+
+## User-Invocable Skills
+
+Four skills are available from the `/` menu:
+
+| Skill | Usage |
+|-------|-------|
+| `/ignition-scada:ignition-lint` | Lint files or the whole project |
+| `/ignition-scada:init-testing` | Scaffold Jython test framework |
+| `/ignition-scada:init-e2e` | Scaffold Playwright browser tests |
+| `/ignition-scada:test` | Run gateway or browser tests |
+
+See the [Skills Reference](skills-reference) for detailed usage of each.
+
+## Plugin vs Templates
+
+This repo offers two ways to give Claude Ignition awareness:
+
+| | Plugin (`claude-code-plugin/`) | Templates (`templates/`) |
+|--|------|-----------|
+| **Scope** | Global — works across all your Ignition projects | Per-project — files live in your project repo |
+| **Install** | `claude plugin add` once | Copy files or run `setup.sh` per project |
+| **Updates** | `claude plugin update` | Re-run setup or manually copy |
+| **Best for** | Developers who work on multiple Ignition projects | Teams who want the config checked into their project |
+
+Both approaches include the same lint hook and the same domain knowledge. The plugin packages it as a reusable install; the templates embed it directly.

--- a/docs/claude-code-plugin/skills-reference.md
+++ b/docs/claude-code-plugin/skills-reference.md
@@ -1,0 +1,196 @@
+---
+sidebar_position: 3
+---
+
+# Skills Reference
+
+The Claude Code plugin bundles 8 skills: 4 Claude-only (background knowledge) and 4 user-invocable (available from the `/` menu).
+
+## Claude-Only Skills
+
+These skills are never shown in the `/` menu. Claude loads them automatically when the context is relevant — you don't need to invoke them.
+
+### ignition-api
+
+**Teaches Claude:** The complete Ignition `system.*` scripting API.
+
+Claude learns:
+- All 14 `system.*` modules with 239 functions, including signatures and return types
+- Jython 2.7 conventions: `print()` function form, no f-strings, no type hints, Java class imports
+- `resource.json` requirements — every file in an Ignition project needs one, and the `files` array must list every file the gateway should load
+- Script library structure: leaf modules (have `code.py`) vs package nodes (have child directories, no `code.py`)
+- Common patterns: parameterized queries, tag reads, dataset iteration, logging
+- Anti-patterns: string-formatted SQL, `import *`, hardcoded gateway URLs, shadowing `system`
+
+### ignition-expressions
+
+**Teaches Claude:** The Ignition expression language (NOT Python).
+
+Claude learns:
+- All 104 built-in functions across 10 categories: math (12), string (24), date/time (16), logic (8), type casting (7), dataset (10), JSON (8), tag quality (7), color (2), advanced (10)
+- Expression syntax: `if({[.]value} > 100, "High", "Normal")`
+- Property references: `{this.props.value}`, `{view.custom.x}`, `{view.params.x}`
+- Key rules: `now()` defaults to 1-second polling (always specify rate), `runScript()` for calling project scripts from expressions
+- Common mistakes: confusing expression syntax with Python
+
+### ignition-testing
+
+**Teaches Claude:** The Jython test framework reference.
+
+Claude learns:
+- All `testing.*` modules: runner, assertions, decorators, helpers, reporter
+- Test discovery convention: `__tests__/code.py` inside the package being tested
+- Decorator usage: `@test`, `@skip(reason)`, `@setup`, `@teardown`, `@expected_error(ExceptionType)`
+- All 11 assertion functions with signatures
+- WebDev endpoint API: `testing/run` (discover, execute, format options) and `testing/tags` (read, write, script invocation, delete)
+- Project inheritance: framework inherited from parent, WebDev endpoints always project-scoped
+- Runner discovery: how the filesystem walk works, what to do when child project tests are not discovered
+- `resource.json` is required for every test module — the number one cause of test discovery failures
+
+### ignition-e2e
+
+**Teaches Claude:** Playwright testing for Perspective views.
+
+Claude learns:
+- Perspective DOM conventions: `data-component-path` (positional indices with `C`, `L[n]`, `T[n]` prefixes), `data-component` type attributes
+- PerspectivePage page object: `openPage()`, `waitForPageContent()`, `componentByType()`, `pageLabelWithText()`, `dismissPopups()`
+- Component wrappers: Button (`click()`, `isEnabled()`), Table (`waitForData()`, `getRowCount()`, `getCellText()`)
+- Gateway API helper: `readTags()`, `writeTags()`, `callScript()`, `mirrorTags()`, `isGatewayReachable()`
+- Auth fixture: auto-login, session persistence to `.auth/user.json`, credential handling via environment variables
+- Critical rules: never use `page.goto()` after initial session open, left dock is `onDemand`, embedded views reset path counters
+
+---
+
+## User-Invocable Skills
+
+These skills appear in the `/` menu and can be invoked directly.
+
+### ignition-lint
+
+**Usage:** `/ignition-scada:ignition-lint [file|directory|profile]`
+
+Runs `ignition-lint` to validate Ignition project files. The linter checks Jython scripts, Perspective views, tag definitions, and expression bindings.
+
+**Arguments:**
+- A file or directory path — lint that specific target
+- A profile name — use that profile on the project
+- Empty — lint the whole project with the `default` profile
+
+**Profiles:** `default`, `full`, `scripts-only`, `perspective-only`, `naming-only`
+
+**Examples:**
+
+```
+/ignition-scada:ignition-lint
+/ignition-scada:ignition-lint scripts-only
+/ignition-scada:ignition-lint ignition/script-python/core/util/code.py
+```
+
+**Diagnostic codes:**
+
+| Category | Codes |
+|----------|-------|
+| Script | `JYTHON_SYNTAX_ERROR`, `JYTHON_PRINT_STATEMENT`, `JYTHON_IMPORT_STAR`, `JYTHON_DEPRECATED_ITERITEMS`, `JYTHON_MIXED_INDENTATION`, `JYTHON_BAD_COMPONENT_REF`, `JYTHON_HARDCODED_LOCALHOST`, `JYTHON_HTTP_WITHOUT_EXCEPTION_HANDLING`, `IGNITION_SYSTEM_OVERRIDE`, `IGNITION_HARDCODED_GATEWAY`, `IGNITION_HARDCODED_DB`, `IGNITION_DEBUG_PRINT`, `IGNITION_UNKNOWN_SYSTEM_CALL`, `LONG_LINE`, `MISSING_DOCSTRING` |
+| Expression | `EXPR_NOW_DEFAULT_POLLING`, `EXPR_NOW_LOW_POLLING`, `EXPR_UNKNOWN_FUNCTION`, `EXPR_INVALID_PROPERTY_REF`, `EXPR_BAD_COMPONENT_REF` |
+| Perspective | `EMPTY_COMPONENT_NAME`, `GENERIC_COMPONENT_NAME`, `MISSING_TAG_PATH`, `MISSING_TAG_FALLBACK`, `MISSING_EXPRESSION`, `INVALID_BINDING_TYPE`, `UNUSED_CUSTOM_PROPERTY`, `UNUSED_PARAM_PROPERTY`, `PERFORMANCE_CONSIDERATION`, `ACCESSIBILITY_LABELING` |
+| Tag | `INVALID_TAG_TYPE`, `MISSING_DATA_TYPE`, `MISSING_VALUE_SOURCE`, `MISSING_TYPE_ID`, `OPC_MISSING_CONFIG`, `EXPR_MISSING_EXPRESSION`, `HISTORY_NO_PROVIDER` |
+
+**Prerequisite:** `pip install ignition-lint-toolkit`
+
+### init-testing
+
+**Usage:** `/ignition-scada:init-testing [--all] [--force]`
+
+Scaffolds the Jython test framework, WebDev test endpoints, and type stubs into the current Ignition project.
+
+**What it creates:**
+
+| Component | Path | Inherited? |
+|-----------|------|-----------|
+| Test runner | `ignition/script-python/testing/runner/` | Yes (from parent) |
+| Assertions | `ignition/script-python/testing/assertions/` | Yes |
+| Decorators | `ignition/script-python/testing/decorators/` | Yes |
+| Helpers | `ignition/script-python/testing/helpers/` | Yes |
+| Reporter | `ignition/script-python/testing/reporter/` | Yes |
+| Run endpoint | `com.inductiveautomation.webdev/resources/testing/run/` | No (project-scoped) |
+| Tags endpoint | `com.inductiveautomation.webdev/resources/testing/tags/` | No (project-scoped) |
+| Type stubs | `.ignition-stubs/testing/` | N/A (local files) |
+
+**Flags:**
+- `--all` — After completing test setup, automatically proceed to scaffold e2e tests (if Perspective is detected)
+- `--force` — Overwrite existing files
+
+**Flow:**
+1. Runs `detect-project.sh` to discover project context
+2. Presents findings (project name, gateway, parent, tag providers)
+3. Asks user to confirm tag provider
+4. Checks for project inheritance — skips framework modules if parent has them
+5. Runs `scaffold-testing.sh`
+6. Verifies setup by hitting the discovery endpoint (if gateway is reachable)
+7. Explains how to write the first test
+
+### init-e2e
+
+**Usage:** `/ignition-scada:init-e2e [--force]`
+
+Scaffolds Playwright browser tests for Perspective views.
+
+**What it creates:**
+
+| Component | Path |
+|-----------|------|
+| Playwright config | `e2e/playwright.config.ts` |
+| Auth fixture | `e2e/fixtures/auth.setup.ts` |
+| Perspective fixture | `e2e/fixtures/perspective.ts` |
+| PerspectivePage | `e2e/pages/PerspectivePage.ts` |
+| Button wrapper | `e2e/components/Button.ts` |
+| Table wrapper | `e2e/components/Table.ts` |
+| Gateway API helper | `e2e/helpers/gateway-api.ts` |
+| Smoke tests | `e2e/tests/smoke/*.spec.ts` |
+| Environment template | `e2e/.env.example` |
+| Package config | `e2e/package.json`, `e2e/tsconfig.json` |
+
+**Flags:**
+- `--force` — Overwrite existing files
+
+**Flow:**
+1. Runs `detect-project.sh`
+2. Checks for Perspective module (`com.inductiveautomation.perspective/`)
+3. If Jython test framework is not set up, scaffolds it first (the gateway API helper depends on `testing/tags`)
+4. Runs `scaffold-e2e.sh`
+5. Installs dependencies (`npm install`, `playwright install chromium`)
+6. Sets up `.env` (copies from parent if available, otherwise uses template)
+7. Explains auth setup and how to run smoke tests
+
+**Prerequisite:** Node.js must be installed. Chromium is installed automatically by Playwright.
+
+### test
+
+**Usage:** `/ignition-scada:test [module|package|ui|e2e|smoke]`
+
+Runs gateway Jython tests or Playwright browser tests. Default is always gateway tests.
+
+**Routing table:**
+
+| Argument | Action |
+|----------|--------|
+| *(empty)* | Run all gateway Jython tests |
+| `<short-name>` (e.g., `changeover`) | Find matching module, run gateway test |
+| `<dotted.path>` (e.g., `core.mes`) | Run as package filter for gateway tests |
+| `ui` or `e2e` | Run all Playwright browser tests |
+| `ui <area>` (e.g., `ui changeover`) | Run Playwright tests in `e2e/tests/<area>/` |
+| `ui smoke` | Run Playwright smoke tests |
+| `smoke` | Run gateway tests (NOT Playwright — "smoke" without `ui` prefix means gateway) |
+
+**Ambiguity rule:** If the user says "run tests", "test it", or any unqualified test request, the skill always defaults to gateway Jython tests. Playwright is only used when explicitly requested with `ui`, `e2e`, `browser`, or `playwright`.
+
+**Examples:**
+
+```
+/ignition-scada:test                    # All gateway tests
+/ignition-scada:test changeover         # Gateway tests for changeover module
+/ignition-scada:test core.mes           # Gateway tests for core.mes package
+/ignition-scada:test ui                 # All Playwright tests
+/ignition-scada:test ui smoke           # Playwright smoke tests
+/ignition-scada:test ui changeover      # Playwright tests for changeover area
+```

--- a/docs/claude-code-plugin/skills-reference.md
+++ b/docs/claude-code-plugin/skills-reference.md
@@ -143,12 +143,14 @@ Scaffolds Playwright browser tests for Perspective views.
 | Auth fixture | `e2e/fixtures/auth.setup.ts` |
 | Perspective fixture | `e2e/fixtures/perspective.ts` |
 | PerspectivePage | `e2e/pages/PerspectivePage.ts` |
+| Component base class | `e2e/components/PerspectiveComponent.ts` |
 | Button wrapper | `e2e/components/Button.ts` |
 | Table wrapper | `e2e/components/Table.ts` |
 | Gateway API helper | `e2e/helpers/gateway-api.ts` |
 | Smoke tests | `e2e/tests/smoke/*.spec.ts` |
 | Environment template | `e2e/.env.example` |
 | Package config | `e2e/package.json`, `e2e/tsconfig.json` |
+| Git ignore | `e2e/.gitignore` |
 
 **Flags:**
 - `--force` — Overwrite existing files

--- a/docs/claude-code-plugin/skills-reference.md
+++ b/docs/claude-code-plugin/skills-reference.md
@@ -80,7 +80,7 @@ Runs `ignition-lint` to validate Ignition project files. The linter checks Jytho
 
 **Examples:**
 
-```
+```bash
 /ignition-scada:ignition-lint
 /ignition-scada:ignition-lint scripts-only
 /ignition-scada:ignition-lint ignition/script-python/core/util/code.py
@@ -188,7 +188,7 @@ Runs gateway Jython tests or Playwright browser tests. Default is always gateway
 
 **Examples:**
 
-```
+```bash
 /ignition-scada:test                    # All gateway tests
 /ignition-scada:test changeover         # Gateway tests for changeover module
 /ignition-scada:test core.mes           # Gateway tests for core.mes package

--- a/docs/claude-code-plugin/testing.md
+++ b/docs/claude-code-plugin/testing.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 The Claude Code plugin provides a complete testing story for Ignition projects: a Jython test framework that runs on the gateway with full access to `system.*` APIs, real tags, and database connections, plus Playwright browser tests for Perspective views. Two commands get you from zero to a full test suite.
 
-```
+```bash
 /ignition-scada:init-testing    # Gateway Jython tests
 /ignition-scada:init-e2e        # Playwright browser tests (Perspective)
 ```
@@ -36,13 +36,13 @@ Plus two WebDev endpoints:
 
 Run the init-testing skill:
 
-```
+```bash
 /ignition-scada:init-testing
 ```
 
 The plugin auto-detects your project — name, gateway, tag providers, parent project inheritance — and scaffolds everything:
 
-```
+```text
 > /ignition-scada:init-testing
 
   Here's what I found:
@@ -92,7 +92,7 @@ If the parent project already has the test framework, the scaffolding uses `--sk
 
 Tests go **inside the package they test** as a `__tests__` subdirectory. Never create standalone top-level test packages.
 
-```
+```text
 CORRECT:
 ignition/script-python/core/util/__tests__/code.py          # tests core.util
 ignition/script-python/core/mes/changeover/__tests__/code.py # tests core.mes.changeover
@@ -218,7 +218,7 @@ HTTP response codes: **200** = all passed, **207** = failures/errors, **500** = 
 
 **Via Claude Code:**
 
-```
+```bash
 /ignition-scada:test                    # All gateway Jython tests
 /ignition-scada:test changeover         # Specific module
 /ignition-scada:test core.mes           # By package prefix
@@ -321,13 +321,13 @@ The `/ignition-scada:init-e2e` command creates a complete Playwright test setup 
 
 ### How to Scaffold
 
-```
+```bash
 /ignition-scada:init-e2e
 ```
 
 Example flow:
 
-```
+```text
 > /ignition-scada:init-e2e
 
   Perspective module found. Parent project has e2e/.env — copying
@@ -559,7 +559,7 @@ npx playwright show-report
 
 Via Claude Code:
 
-```
+```bash
 /ignition-scada:test ui                 # All Playwright browser tests
 /ignition-scada:test ui smoke           # Playwright smoke tests only
 /ignition-scada:test ui changeover      # Specific area

--- a/docs/claude-code-plugin/testing.md
+++ b/docs/claude-code-plugin/testing.md
@@ -1,0 +1,652 @@
+---
+sidebar_position: 2
+---
+
+# Testing
+
+The Claude Code plugin provides a complete testing story for Ignition projects: a Jython test framework that runs on the gateway with full access to `system.*` APIs, real tags, and database connections, plus Playwright browser tests for Perspective views. Two commands get you from zero to a full test suite.
+
+```
+/ignition-scada:init-testing    # Gateway Jython tests
+/ignition-scada:init-e2e        # Playwright browser tests (Perspective)
+```
+
+## Gateway Jython Tests
+
+### What the Framework Provides
+
+The Jython test framework is a set of script library modules that run inside the Ignition gateway. It consists of five modules:
+
+| Module | Purpose |
+|--------|---------|
+| `testing.runner` | Discovers `__tests__` modules by walking the filesystem, imports them, executes `@test`-decorated functions |
+| `testing.assertions` | 11 assertion functions that raise `TestAssertionError` with structured `actual`/`expected` attributes |
+| `testing.decorators` | `@test`, `@skip`, `@setup`, `@teardown`, `@expected_error` |
+| `testing.helpers` | Utility functions for tag setup/teardown (DataSet writing, tag reconfiguration) |
+| `testing.reporter` | Output formatting — JSON, console text, JUnit XML |
+
+Plus two WebDev endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `testing/run` | HTTP API for test discovery and execution (GET for discover, POST to run) |
+| `testing/tags` | HTTP API for tag read/write/delete and script invocation from external tools |
+
+### How to Scaffold
+
+Run the init-testing skill:
+
+```
+/ignition-scada:init-testing
+```
+
+The plugin auto-detects your project — name, gateway, tag providers, parent project inheritance — and scaffolds everything:
+
+```
+> /ignition-scada:init-testing
+
+  Here's what I found:
+
+  Property    Value
+  ----------  ------------------------------------------
+  Project     My Site HMI (MySiteHMI)
+  Gateway     https://localhost:9043 (reachable)
+  Parent      Global (has Jython framework + WebDev)
+  Tag provs   SITE01, default
+
+  Inherited from parent (NOT created here):
+  The Jython test framework lives in Global and is inherited
+  automatically. Any __tests__ modules you write will be
+  discovered alongside the parent's tests.
+
+  Created here (project-scoped, NOT inherited):
+  - WebDev endpoints (testing/run, testing/tags)
+  - Type stubs (.ignition-stubs/testing/)
+
+  Which tag provider? > SITE01
+
+  Scaffold complete: 14 created, 0 skipped.
+
+  Gateway discovered 11 test modules:
+  core.mes.changeover.__tests__, core.util.__tests__, ...
+
+  Writing your first test:
+  ignition/script-python/<package>/__tests__/code.py
+```
+
+### Project Inheritance
+
+Ignition projects can inherit from a parent project. The scaffolding understands this:
+
+**Inherited from parent (NOT created locally):**
+- The Jython test framework (`testing.*` modules) — lives in the parent, shared across all child projects
+- Test modules (`__tests__/code.py`) — can exist in both parent and child; the runner discovers all of them
+
+**Always created locally (NOT inherited in Ignition):**
+- WebDev endpoints (`testing/run`, `testing/tags`) — HTTP APIs are project-scoped in Ignition. Each project needs its own endpoints even if the scripts behind them are inherited.
+- Type stubs (`.ignition-stubs/testing/`) — local files for IDE completion, not Ignition resources
+
+If the parent project already has the test framework, the scaffolding uses `--skip-scripts` to avoid duplicating it. If the parent project is not found on disk, the plugin asks whether to scaffold everything locally or provide the parent path.
+
+### Writing Tests
+
+Tests go **inside the package they test** as a `__tests__` subdirectory. Never create standalone top-level test packages.
+
+```
+CORRECT:
+ignition/script-python/core/util/__tests__/code.py          # tests core.util
+ignition/script-python/core/mes/changeover/__tests__/code.py # tests core.mes.changeover
+
+WRONG:
+ignition/script-python/tests/__tests__/code.py               # standalone — no matching code
+```
+
+A test file looks like this:
+
+```python
+from testing.decorators import test, skip, setup, teardown, expected_error
+from testing.assertions import assert_equal, assert_true, assert_not_none, assert_raises
+
+@setup
+def setup_module():
+    """Runs once before all tests in this module."""
+    pass
+
+@teardown
+def teardown_module():
+    """Runs once after all tests in this module."""
+    pass
+
+@test
+def test_basic_logic():
+    result = 2 + 2
+    assert_equal(result, 4, "basic math works")
+
+@test
+def test_tag_value():
+    result = system.tag.readBlocking(["[default]Some/Tag"])[0]
+    assert_not_none(result.value, "tag should have a value")
+    assert_true(result.quality.isGood(), "tag quality should be good")
+
+@skip("waiting on PLC config")
+@test
+def test_not_ready_yet():
+    pass
+
+@expected_error(ValueError)
+@test
+def test_bad_input():
+    int("not a number")
+```
+
+Every test directory needs a `resource.json` alongside `code.py` — without it, Ignition silently ignores the module:
+
+```json
+{
+  "scope": "A",
+  "version": 1,
+  "restricted": false,
+  "overridable": true,
+  "files": ["code.py"],
+  "attributes": {
+    "lastModification": {
+      "actor": "external",
+      "timestamp": "2026-01-01T00:00:00Z"
+    }
+  }
+}
+```
+
+### Decorators
+
+| Decorator | Purpose |
+|-----------|---------|
+| `@test` | Marks a function as a test case. The runner discovers functions with `_is_test = True`. |
+| `@skip(reason="")` | Skips the test. Apply **before** `@test`: `@skip("reason")` then `@test` on the next line. |
+| `@setup` | Module-level setup — runs once before all tests. One per module. |
+| `@teardown` | Module-level teardown — runs once after all tests. One per module. |
+| `@expected_error(ExceptionType)` | Test passes if the given exception is raised, fails otherwise. |
+
+### Assertions
+
+| Function | Purpose |
+|----------|---------|
+| `assert_equal(actual, expected, msg=None)` | `actual == expected` |
+| `assert_not_equal(actual, expected, msg=None)` | `actual != expected` |
+| `assert_true(val, msg=None)` | `val` is truthy |
+| `assert_false(val, msg=None)` | `val` is falsy |
+| `assert_none(val, msg=None)` | `val is None` |
+| `assert_not_none(val, msg=None)` | `val is not None` |
+| `assert_close(actual, expected, tolerance=0.001, msg=None)` | Floating point comparison within tolerance |
+| `assert_raises(callable_fn, exception_type, msg=None)` | `callable_fn()` raises `exception_type`. Returns the caught exception. |
+| `assert_tag_value(tag_path, expected, msg=None)` | Reads a real gateway tag and asserts its value. Uses `system.tag.readBlocking`. |
+| `assert_contains(container, item, msg=None)` | `item in container` |
+| `assert_isinstance(obj, expected_type, msg=None)` | `isinstance(obj, expected_type)` |
+
+All assertions raise `TestAssertionError` (subclass of `AssertionError`) with `actual` and `expected` attributes for structured reporting.
+
+### Running Tests
+
+**From the Script Console:**
+
+```python
+print testing.runner.run_all()
+print testing.runner.run_module("core.mes.changeover.__tests__")
+print testing.reporter.to_console(testing.runner.run_all())
+```
+
+**Via HTTP (WebDev endpoints):**
+
+```bash
+# Discover test modules
+curl -k -s "https://localhost:9043/system/webdev/MySiteHMI/testing/run?discover=true"
+
+# Run all tests
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/run"
+
+# Run specific module
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/run?module=core.mes.changeover.__tests__"
+
+# Run by package prefix
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/run?package=core.mes"
+
+# Output formats: json (default), junit, text
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/run?format=text"
+```
+
+HTTP response codes: **200** = all passed, **207** = failures/errors, **500** = runner error.
+
+**Via Claude Code:**
+
+```
+/ignition-scada:test                    # All gateway Jython tests
+/ignition-scada:test changeover         # Specific module
+/ignition-scada:test core.mes           # By package prefix
+```
+
+### WebDev Endpoints
+
+#### testing/run
+
+| Method | Query Params | Description |
+|--------|-------------|-------------|
+| GET | `discover=true` | List all discovered test modules |
+| POST | *(none)* | Run all tests |
+| POST | `module=<path>` | Run a specific module (e.g., `core.mes.changeover.__tests__`) |
+| POST | `package=<prefix>` | Run all modules matching a package prefix (e.g., `core.mes`) |
+| POST | `format=json\|junit\|text` | Output format (default: `json`) |
+
+#### testing/tags
+
+Read/write tags and invoke scripts from external tools:
+
+```bash
+# Read tags
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"reads": ["[SITE01]Path/To/Tag"]}'
+
+# Write tags (auto-creates if missing)
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"writes": [{"path": "[default]Test/Tag", "value": 42}]}'
+
+# Call a gateway script function
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"script": {"path": "core.util.secrets.get_secret", "args": ["mes-host"]}}'
+
+# Delete tags (cleanup)
+curl -k -s -X POST "https://localhost:9043/system/webdev/MySiteHMI/testing/tags" \
+  -H "Content-Type: application/json" \
+  -d '{"deleteTags": "[default]Test/Tag"}'
+```
+
+### Common Patterns
+
+**Testing a script function that reads tags:**
+
+```python
+@test
+def test_get_area_state():
+    from core.mes.changeover import client
+    result = client.get_state("cooker")
+    assert_not_none(result, "should return state dict")
+    assert_contains(result, "current_state")
+```
+
+**Testing with tag setup/teardown:**
+
+```python
+@setup
+def setup_module():
+    from testing.helpers import write_dataset_tag
+    write_dataset_tag(
+        "[default]Test/Queue",
+        ["Id", "Value"], ["String", "Int4"],
+        [["A", 1], ["B", 2]]
+    )
+
+@teardown
+def teardown_module():
+    from testing.helpers import clear_dataset_tag
+    clear_dataset_tag("[default]Test/Queue", ["Id", "Value"], ["String", "Int4"])
+
+@test
+def test_queue_processing():
+    qv = system.tag.readBlocking(["[default]Test/Queue"])[0]
+    ds = qv.value
+    assert_equal(ds.getRowCount(), 2)
+```
+
+---
+
+## Playwright E2E Tests
+
+### What Gets Scaffolded
+
+The `/ignition-scada:init-e2e` command creates a complete Playwright test setup for Perspective views:
+
+| Component | Description |
+|-----------|-------------|
+| `playwright.config.ts` | Playwright config with auth project, base URL, timeouts |
+| `fixtures/auth.setup.ts` | Auto-login, session persistence to `.auth/user.json` |
+| `fixtures/perspective.ts` | Custom test fixture providing `PerspectivePage` |
+| `pages/PerspectivePage.ts` | Base page object for Perspective DOM conventions |
+| `components/Button.ts` | Wrapper for `ia.input.button` |
+| `components/Table.ts` | Wrapper for `ia.display.table` |
+| `helpers/gateway-api.ts` | Tag read/write, script invocation, health checks via WebDev |
+| `tests/smoke/*.spec.ts` | Smoke tests for session loading, dock rendering, page content |
+| `.env.example` | Environment variable template |
+
+### How to Scaffold
+
+```
+/ignition-scada:init-e2e
+```
+
+Example flow:
+
+```
+> /ignition-scada:init-e2e
+
+  Perspective module found. Parent project has e2e/.env — copying
+  credentials and updating project name.
+
+  Scaffold done: 13 files created.
+
+  Installing dependencies...
+  npm install done
+  playwright install chromium done
+
+> Yes, run the auth setup and smoke tests
+
+  authenticate (4.6s)
+  session loads and docks render (2.8s)
+  page content renders (2.7s)
+  navigation exists in DOM (3.9s)
+
+  4 passed, 0 failed (19s total)
+```
+
+### Auth Setup
+
+The auth fixture (`fixtures/auth.setup.ts`) handles Perspective authentication:
+
+1. Navigates to `/data/perspective/client/<PROJECT>`
+2. Polls for login form (`input.username-field`) or existing live session (`[data-component]`)
+3. If login form appears: fills credentials from `IGNITION_USER`/`IGNITION_PASSWORD` environment variables
+4. Persists session to `.auth/user.json` for reuse across tests
+
+If auth fails or expires, re-authenticate:
+
+```bash
+cd e2e && npx playwright test --project=setup
+```
+
+### Environment Variables
+
+Set in `e2e/.env` (never committed — included in `.gitignore`):
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `IGNITION_URL` | Gateway base URL | `https://localhost:9043` |
+| `IGNITION_USER` | Login username | `admin` |
+| `IGNITION_PASSWORD` | Login password | `password` |
+| `PERSPECTIVE_PROJECT` | Perspective project name | `MySiteHMI` |
+| `TAG_PROVIDER` | Default tag provider | `SITE01` |
+
+### PerspectivePage
+
+The base page object wraps Playwright's `Page` for Perspective conventions:
+
+```typescript
+import { PerspectivePage } from "../pages/PerspectivePage";
+
+// Navigation
+perspective.openPage("/route")           // Open a page route (call once per test)
+perspective.waitForPageContent(timeout?)  // Wait for C-prefixed content to render
+perspective.waitForSession(timeout?)      // Wait for any [data-component] elements
+
+// Locators
+perspective.pageContent()                // Scoped to page content (excludes docks)
+perspective.componentByType("ia.display.label")  // Find by component type
+perspective.pageLabelWithText("Title")   // Find label with specific text
+perspective.pageText("some text")        // Find visible text in page content
+
+// Utilities
+perspective.dismissPopups()              // Close popup overlays
+perspective.dumpComponentPaths()         // Debug: list all component paths in DOM
+```
+
+### Perspective DOM Conventions
+
+Perspective is a React SPA served over WebSocket. Every component has `data-component-path` using positional indices, not the named paths from `view.json`.
+
+**Prefix convention:**
+
+| Prefix | Meaning |
+|--------|---------|
+| `C` | Center (page content) |
+| `L[n]` | Left dock (e.g., `L[0]`, `L[1]`) |
+| `T[n]` | Top dock (e.g., `T[0]`) |
+| `$` | Embedded view boundary |
+| `:` | Child index separator |
+
+**Examples:**
+- `C` — root page content container
+- `C:0:1` — second child of first child of page content
+- `C:0$0:2` — embedded view boundary, then third child
+- `T[0]:0:1` — top dock, first container, second child
+
+**Key rules:**
+1. Never use `page.goto()` after initial session open — it creates a new WebSocket session. Use `perspective.openPage(route)` instead.
+2. Page content is scoped by `C` prefix — use `perspective.pageContent()` to exclude docks.
+3. Docks render independently — top dock (`T[0]`) may be visible before page content (`C`).
+4. Embedded views reset the path counter — `$` marks the boundary, child indices restart from 0.
+5. Left dock is often `onDemand` — check `toBeAttached()` not `toBeVisible()`.
+
+### Component Wrappers
+
+#### Button (`ia.input.button`)
+
+```typescript
+const btn = new Button(locator, page);
+await btn.click()       // Wait for visible, then click
+await btn.isEnabled()   // Checks for "ia_button--disabled" class
+```
+
+#### Table (`ia.display.table`)
+
+```typescript
+const table = new Table(locator, page);
+await table.waitForData(timeout?)       // Wait for first row to render
+await table.getRowCount()               // Number of visible rows
+await table.clickRow(index)             // Click row by index
+await table.getCellText(row, column)    // Get cell text content
+```
+
+### Gateway API Helper
+
+Call WebDev endpoints from test code to set up state, read tags, or invoke gateway scripts:
+
+```typescript
+import {
+  readTags, writeTags, readTag, writeTag,
+  callScript, isGatewayReachable, mirrorTags, deleteMirror
+} from "../helpers/gateway-api";
+
+// Tag operations
+const values = await readTags(["[SITE01]Path/To/Tag1", "[SITE01]Path/To/Tag2"]);
+const val = await readTag("[SITE01]Path/To/Tag");
+await writeTag("[default]Test/Tag", 42);
+
+// Script invocation — call real Jython scripts on the gateway
+const result = await callScript("core.mes.changeover.client.get_state", ["cooker"]);
+
+// Tag mirroring — clone OPC tags to memory for testing without PLC
+await mirrorTags("[SITE01]Area/Equipment", "[SITE01]Area/Equipment_MEM");
+// ... run tests against memory tags ...
+await deleteMirror("[SITE01]Area/Equipment_MEM");
+
+// Health check
+const reachable = await isGatewayReachable();
+```
+
+### Writing Tests
+
+**Basic smoke test:**
+
+```typescript
+import { test, expect } from "../../fixtures/perspective";
+
+test.describe("Overview smoke tests", () => {
+  test("page loads with expected title", async ({ perspective }) => {
+    await perspective.openPage("/overview");
+    const title = perspective.pageLabelWithText("Plant Overview");
+    await expect(title.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("table renders with data", async ({ perspective }) => {
+    await perspective.openPage("/overview");
+    const table = perspective.componentByType("ia.display.table");
+    await expect(table.first()).toBeVisible();
+    await expect(
+      table.locator(".ia_table__body__row").first()
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+**Integration test with tag setup:**
+
+```typescript
+import { test, expect } from "../../fixtures/perspective";
+import { writeTag, callScript } from "../../helpers/gateway-api";
+
+test.describe("Changeover integration", () => {
+  test.beforeAll(async () => {
+    await writeTag("[default]Test/State", "idle");
+  });
+
+  test.afterAll(async () => {
+    await writeTag("[default]Test/State", "");
+  });
+
+  test("state change reflects in UI", async ({ perspective }) => {
+    await perspective.openPage("/changeover");
+    await callScript("core.mes.changeover.client.transition", ["cooker", "start"]);
+    const label = perspective.pageText("running");
+    await expect(label).toBeVisible({ timeout: 10_000 });
+  });
+});
+```
+
+**Testing docks:**
+
+```typescript
+test("left dock menu exists", async ({ perspective }) => {
+  await perspective.openPage("/some-page");
+  // Left dock is onDemand — check attached, not visible
+  const menu = perspective.page.locator("[data-component='ia.navigation.menutree']");
+  await expect(menu).toBeAttached({ timeout: 10_000 });
+});
+```
+
+### Running Tests
+
+```bash
+cd e2e
+
+# All tests
+npx playwright test
+
+# Specific area
+npx playwright test tests/changeover/
+
+# Smoke tests only
+npx playwright test tests/smoke/
+
+# Headed mode (see the browser)
+npx playwright test --headed
+
+# Single test file
+npx playwright test tests/smoke/perspective-loads.spec.ts
+
+# View HTML report after failures
+npx playwright show-report
+```
+
+Via Claude Code:
+
+```
+/ignition-scada:test ui                 # All Playwright browser tests
+/ignition-scada:test ui smoke           # Playwright smoke tests only
+/ignition-scada:test ui changeover      # Specific area
+```
+
+### Common Pitfalls
+
+1. **Perspective takes 30-45s to reload after a project scan.** The auth fixture has a 45s timeout for this reason. If tests fail immediately after a scan, wait and retry.
+2. **Don't call `page.goto()` mid-test.** This kills the WebSocket session. Navigate within Perspective using component interactions or `openPage()` for the initial load.
+3. **Embedded views load asynchronously.** Wait for specific content inside them, don't rely on the parent container being visible.
+4. **Tables render headers before data.** Use `table.waitForData()` or wait for `.ia_table__body__row` specifically.
+5. **Popups from startup scripts** can block interaction. Call `perspective.dismissPopups()` after `openPage()` if needed.
+
+---
+
+## Auto-Test Hooks
+
+The plugin includes two PostToolUse hooks that run tests automatically.
+
+### Post-Commit Gateway Tests
+
+After every `git commit` (detected by inspecting Bash tool output), the `run-tests.sh` hook:
+
+1. Checks if the working directory is inside an Ignition project (`project.json` exists)
+2. Checks if test infrastructure is set up (`testing/run` WebDev endpoint exists)
+3. Checks if the gateway is reachable
+4. Optionally triggers a project scan (if `IGNITION_API_TOKEN_FILE` is set)
+5. Waits 3 seconds for scan propagation
+6. Runs all tests via `testing/run` endpoint
+7. Reports pass/fail summary to Claude
+
+If any check fails, the hook silently exits. It is safe for global install.
+
+### Post-Edit Playwright Tests
+
+After every Write or Edit on a `view.json` file inside `com.inductiveautomation.perspective/views/`, the `run-ui-tests.sh` hook:
+
+1. Checks if the file is a Perspective view
+2. Checks if `e2e/` is set up (has `node_modules` and `.auth/user.json`)
+3. Extracts the view area name from the file path
+4. If matching tests exist in `e2e/tests/<area>/`, runs those. Otherwise, runs smoke tests.
+5. Uses a directory-based lock to prevent concurrent Playwright runs
+
+### Self-Gating
+
+Both hooks silently exit when they detect any of these conditions:
+- Not inside an Ignition project (no `project.json` in any parent directory)
+- Test infrastructure not scaffolded
+- Gateway not reachable (post-commit hook)
+- E2E not set up (post-edit hook)
+
+This means you can install the plugin globally and it will only activate when you are actually working on an Ignition project with tests configured.
+
+---
+
+## Deterministic Mode
+
+All scaffolding scripts can be run directly from the command line, without Claude:
+
+```bash
+# Detect project structure
+./scripts/detect-project.sh /path/to/project
+
+# Scaffold Jython test framework
+./scripts/scaffold-testing.sh \
+  --project-root /path/to/project \
+  --project-name MySiteHMI \
+  --tag-provider SITE01
+
+# Scaffold Playwright e2e tests
+./scripts/scaffold-e2e.sh \
+  --project-root /path/to/project \
+  --project-name MySiteHMI \
+  --tag-provider SITE01 \
+  --perspective-project MySiteHMI
+```
+
+### Flags
+
+| Flag | Applies to | Description |
+|------|-----------|-------------|
+| `--dry-run` | Both | Preview what would be created without writing files |
+| `--force` | Both | Overwrite existing files |
+| `--skip-scripts` | `scaffold-testing.sh` | Skip the Jython framework modules (use when parent project already has them) |
+
+### Prerequisites
+
+- **Gateway tests:** A running Ignition gateway (local or Docker)
+- **E2E tests:** Node.js, Chromium (installed automatically by Playwright)
+- **Both:** `jq` for the detection script (pre-installed on most systems)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,7 +5,12 @@ slug: /
 
 # Introduction
 
-**ignition-nvim** is a Neovim plugin for developers working with [Ignition by Inductive Automation](https://inductiveautomation.com/). It brings first-class IDE support for Ignition development directly into your terminal workflow.
+**Ignition Dev Tools** is a multi-editor monorepo providing full IDE support for [Ignition by Inductive Automation](https://inductiveautomation.com/). It brings first-class development tooling to Neovim, VS Code, and Claude Code — covering everything from LSP completions to automated test scaffolding.
+
+Part of the **Whiskey House Ignition Developer Toolkit**:
+- **Ignition Dev Tools** — IDE support for Neovim, VS Code, and Claude Code (this project)
+- [**ignition-lint**](https://pypi.org/project/ignition-lint-toolkit/) — Static analysis for Ignition Python scripts
+- **ignition-git-module** — Native Git integration inside Ignition Designer
 
 ## The Problem
 
@@ -16,35 +21,53 @@ Developing Ignition projects outside the Designer is painful:
 - **No schema validation** — Tag JSON and Perspective component definitions have strict schemas that generic editors can't validate
 - **Embedded scripts** — Python code is stored inside JSON files using Ignition's custom encoding format, making editing tedious
 - **Limited tooling** — The Designer's built-in editor lacks modern IDE features (LSP, plugins, advanced motions)
+- **No testing** — No standard framework for unit testing Jython scripts or browser-testing Perspective views
 
 ## The Solution
 
-ignition-nvim brings modern IDE capabilities to Ignition development:
+Ignition Dev Tools brings modern IDE capabilities to Ignition development across three editors:
 
 - **Full LSP integration** — Context-aware completions for all `system.*` APIs (239+ functions), Java/Jython classes (146 classes), and project scripts
-- **Schema validation** — Built-in validation for Tag JSON and Perspective component definitions with inline error reporting
 - **Intelligent decode/encode** — Seamlessly edit embedded Python scripts with full syntax highlighting and LSP support, auto-encoded on save
 - **Type-aware completions** — Understands Jython's Java interop, providing accurate completions for `java.util.*`, `javax.swing.*`, and Ignition SDK classes
 - **Project navigation** — Workspace symbols, go-to-definition, and cross-file script references
-
-## Features
-
-- **Script Decode/Encode** — Extract embedded Python from JSON, edit with full syntax highlighting, save back seamlessly
-- **LSP Completions** — `system.tag.read`, `system.db.runQuery`, and 239+ Ignition API functions plus 146 Java classes with signatures and docs
-- **Hover Documentation** — Inline parameter info and return types for all Ignition and Java API calls
 - **Diagnostics** — Catch errors in your scripts before deploying to the gateway
-- **Kindling Integration** — Open `.gwbk` gateway backup files directly from Neovim
-- **File Type Detection** — Automatic recognition of Ignition project files by extension, filename, path, and content
+- **Claude Code plugin** — Auto-linting, API reference skills, and automated test scaffolding for Jython gateway tests and Playwright browser tests
 
 ## Architecture
 
-ignition-nvim is a hybrid Lua + Python plugin:
+The project is organized as a monorepo with three packages:
 
-- **Lua plugin** (`lua/ignition/`) — Core functionality: decode/encode, virtual buffers, commands, file detection, LSP client
-- **Python LSP server** (`lsp/ignition_lsp/`) — Built on [pygls](https://github.com/openlawlibrary/pygls), provides completions, hover, and diagnostics from a curated API database
+```
+packages/
+├── ignition-lsp/        # Python LSP server (shared by both editors)
+├── ignition-nvim/       # Neovim plugin (Lua)
+└── ignition-vscode/     # VS Code extension (TypeScript)
+```
+
+### Shared LSP Server (`packages/ignition-lsp/`)
+
+A Python language server built on [pygls](https://github.com/openlawlibrary/pygls), providing completions, hover documentation, diagnostics, go-to-definition, and workspace symbols. Both editors use the same server, so all language features are consistent.
+
+- 14 API modules covering 239 `system.*` functions
+- 26 Java packages with 146 classes for Jython interop
+- Pyright/Pylance type stubs for static analysis
+
+### Neovim Plugin (`packages/ignition-nvim/`)
+
+Lua plugin using Neovim 0.11+ native LSP (`vim.lsp.start()`). Provides script decode/encode, virtual buffers, Kindling integration for `.gwbk` files, and file type detection.
+
+### VS Code Extension (`packages/ignition-vscode/`)
+
+TypeScript extension with CodeLens for embedded scripts, a Designer-style project browser sidebar, tag browser, component tree, and one-click decode/encode.
+
+### Claude Code Plugin (`claude-code-plugin/`)
+
+A Claude Code plugin that gives Claude full Ignition domain awareness. Includes auto-linting, the complete `system.*` API reference, expression language catalog, and automated test scaffolding for both Jython gateway tests and Playwright browser tests.
 
 ## Next Steps
 
-- [Install the plugin](getting-started/installation) and LSP server
-- [Try the quickstart](getting-started/quickstart) to decode your first script
-- [Browse all commands](guides/commands) and keymaps
+- **Neovim** — [Install the plugin](getting-started/installation) and LSP server
+- **Neovim** — [Try the quickstart](getting-started/quickstart) to decode your first script
+- **Claude Code** — [Set up the plugin](claude-code-plugin/overview) for auto-linting and testing
+- **Claude Code** — [Scaffold tests](claude-code-plugin/testing) for your Ignition project

--- a/docs/superpowers/plans/2026-03-24-plugin-testing-integration.md
+++ b/docs/superpowers/plans/2026-03-24-plugin-testing-integration.md
@@ -229,7 +229,7 @@ Create the script with these specifications:
 
 5. **reporter/code.py** — Use as-is from WHK-Global (fully generic already)
 
-6. **WebDev run/doGet.py** — Replace `"WHK-Global Test Runner"` with `"${PROJECT_NAME} Test Runner"` (sed replacement)
+6. **WebDev run/doGet.py** — Replace `"WHK-Global Test Runner"` with `"${PROJECT_NAME} — Test Runner"` (sed replacement, em dash avoids awkward "Test Test Runner" for projects named "Test")
 
 7. **WebDev run/doPost.py** — Use as-is (fully generic already — references `testing.runner` and `testing.reporter` which are module-relative)
 
@@ -237,11 +237,11 @@ Create the script with these specifications:
 
 9. **WebDev tags/doPost.py** — Replace hardcoded `/usr/local/bin/ignition/data/projects/WHK-Global` in importTags section. Drop the `mirror` handler that calls `general.tools.conversions.convert_to_memory_tags` (that's a WHK-specific script). Keep: writes, reads, script, deleteTags, importTags (with parameterized path)
 
-10. **config.json** — Use as-is (identical for both endpoints)
+10. **config.json** — Use as-is (identical for both WebDev endpoints). Content is at `~/data/projects/WHK-Global/com.inductiveautomation.webdev/resources/testing/tags/config.json` — enables doGet/doPost with `require-auth: false`, disables all other HTTP methods. Embed as a heredoc in the scaffold script.
 
-11. **resource.json** — Use as-is (identical for all 5 modules)
+11. **resource.json** — Use as-is (identical for all 5 script modules). Content is at `~/data/projects/WHK-Global/ignition/script-python/testing/runner/resource.json` — standard Ignition resource descriptor with `scope: "A"`, `version: 1`, `restricted: false`, `overridable: true`. Embed as a heredoc in the scaffold script — write the same content for all 5 modules.
 
-12. **.pyi stubs** — Use as-is from WHK-Global stubs, minus the `run_process_queue` and `_run_process_queue_direct` entries in helpers.pyi
+12. **.pyi stubs** — Use as-is from WHK-Global stubs at `~/data/projects/WHK-Global/.ignition-stubs/testing/`, minus the `run_process_queue` and `_run_process_queue_direct` entries in helpers.pyi
 
 **Structure:**
 - Parse args with `while` loop and `case` statement
@@ -282,7 +282,7 @@ claude-code-plugin/scripts/scaffold-testing.sh \
 Expected: All files created. Verify:
 - `runner/code.py` contains `PROJECT_NAME = "Test"` (not `WHK-Global`)
 - `helpers/code.py` does NOT contain `run_process_queue`
-- `doGet.py` shows `"Test Test Runner"`
+- `doGet.py` shows `"Test — Test Runner"`
 - `config.json` has `require-auth: false`
 
 Test idempotency:
@@ -296,6 +296,18 @@ claude-code-plugin/scripts/scaffold-testing.sh \
 ```
 
 Expected: All files skipped.
+
+Test `--force` overwrite:
+```bash
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/test-ignition-project \
+  --project-name Test \
+  --gateway-url https://localhost:9043 \
+  --tag-provider NEWTAG \
+  --force
+```
+
+Expected: All files overwritten. Verify tag provider changed where applicable.
 
 Clean up: `rm -rf /tmp/test-ignition-project`
 
@@ -335,7 +347,7 @@ git commit -m "feat(plugin): add scaffold-testing.sh for Jython test framework"
 
 7. **fixtures/perspective.ts** — Use as-is (fully generic)
 
-8. **helpers/gateway-api.ts** — Drop everything below line 176 (MES, WMS, changeover tags, GraphQL sections). Replace hardcoded `WHK-Global` in `WEBDEV` constant with `process.env.IGNITION_PROJECT_NAME || "PROJECT_NAME_PLACEHOLDER"` (sed-replaced by script). Keep: `post()`, `get()`, tag operations, mirror operations, script invocation, health checks.
+8. **helpers/gateway-api.ts** — Drop all sections after the health checks: MES changeover REST API, changeover tag helpers, WMS API (Azure Entra OAuth2), changeover UDT member constants, MES GraphQL API, and `readChangeoverState()`. Replace hardcoded `WHK-Global` in `WEBDEV` constant with `process.env.IGNITION_PROJECT_NAME || "PROJECT_NAME_PLACEHOLDER"` (sed-replaced by script). Keep: `post()`, `get()`, tag operations (readTags, writeTags, readTag, writeTag), mirror operations (mirrorTags, deleteMirror), script invocation (callScript), health checks (getHealth, isGatewayReachable).
 
 9. **pages/PerspectivePage.ts** — Use as-is (already uses env var for project name)
 
@@ -403,7 +415,7 @@ fi
 
 # Check commit succeeded
 STDOUT=$(echo "$INPUT" | jq -r '.tool_result.stdout // empty')
-if [[ ! "$STDOUT" =~ create\ mode|file\ changed|files\ changed|insertions|deletions ]] && [[ ! "$STDOUT" =~ \[ ]]; then
+if [[ ! "$STDOUT" =~ create\ mode|file\ changed|files\ changed|insertions|deletions ]] && [[ ! "$STDOUT" =~ \[[a-z]+\ [a-f0-9] ]]; then
   exit 0
 fi
 
@@ -445,11 +457,8 @@ if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
     "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1 || true
 fi
 
-# Wait for scan propagation (best-effort, max 5s)
-for i in 1 2 3 4 5; do
-  sleep 1
-  curl -k -s --connect-timeout 2 "$GATEWAY_URL/StatusPing" > /dev/null 2>&1 && break
-done
+# Wait for scan propagation (best-effort delay — Ignition has no scan-completion endpoint)
+sleep 3
 
 # Run tests
 ENDPOINT="$GATEWAY_URL/system/webdev/$PROJECT_NAME/testing/run"
@@ -997,7 +1006,18 @@ echo '{"tool_input":{"file_path":"/tmp/foo.py"}}' | \
 
 Both should exit 0 with no output.
 
-- [ ] **Step 6: Clean up and final commit**
+- [ ] **Step 6: Validate skill frontmatter**
+
+```bash
+for skill in claude-code-plugin/skills/*/SKILL.md; do
+  echo "--- $skill ---"
+  head -3 "$skill"
+done
+```
+
+Expected: Each SKILL.md starts with `---` frontmatter containing a `description:` field.
+
+- [ ] **Step 7: Clean up and final commit**
 
 ```bash
 rm -rf /tmp/verify-plugin

--- a/docs/superpowers/plans/2026-03-24-plugin-testing-integration.md
+++ b/docs/superpowers/plans/2026-03-24-plugin-testing-integration.md
@@ -1,0 +1,1006 @@
+# Plugin Testing Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Jython gateway testing, Playwright e2e testing, and auto-scaffolding to the `ignition-scada` Claude Code plugin so any Ignition project gets a complete test setup from one or two commands.
+
+**Architecture:** Layered design — deterministic shell scripts do all file creation (heredocs), skills wrap them with auto-detection and user interaction, hooks self-gate and run tests automatically. All new files go in `claude-code-plugin/`.
+
+**Tech Stack:** Bash (scripts), Markdown (skills), Jython (test framework), TypeScript (Playwright e2e), JSON (configs)
+
+**Spec:** `docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md`
+
+**Source reference:** WHK-Global at `~/data/projects/WHK-Global/` contains the working implementations to genericize.
+
+---
+
+## File Map
+
+### New files to create
+
+```
+claude-code-plugin/
+├── scripts/
+│   ├── detect-project.sh          # Auto-detection script
+│   ├── scaffold-testing.sh        # Jython framework + WebDev endpoints + stubs
+│   ├── scaffold-e2e.sh            # Playwright setup
+│   ├── run-tests.sh               # Post-commit gateway test hook
+│   └── run-ui-tests.sh            # Post-edit Playwright test hook
+├── skills/
+│   ├── init-testing/SKILL.md      # Scaffold Jython + WebDev
+│   ├── init-e2e/SKILL.md          # Scaffold Playwright
+│   └── test/SKILL.md              # Run tests
+```
+
+### Files to modify
+
+```
+claude-code-plugin/
+├── .claude-plugin/plugin.json     # Version bump 0.1.0 → 0.2.0, update description
+├── hooks/hooks.json               # Add run-tests.sh and run-ui-tests.sh hooks
+└── README.md                      # Add testing documentation
+```
+
+---
+
+## Task 1: Detection Script
+
+**Files:**
+- Create: `claude-code-plugin/scripts/detect-project.sh`
+
+The foundation — all skills and scaffold scripts depend on this.
+
+- [ ] **Step 1: Write detect-project.sh**
+
+Create the detection script. It must:
+- Accept optional `$1` as target directory (default: `$PWD`)
+- Walk up from target looking for `project.json`
+- Parse `project.json` with `jq` for `.title`
+- Derive `project_name` from directory name
+- Probe `https://localhost:9043/StatusPing` with `--connect-timeout 3`, fall back to `http://localhost:8088/StatusPing`
+- Check for `com.inductiveautomation.perspective/`, `com.inductiveautomation.webdev/`, `ignition/script-python/`
+- If gateway reachable, query `${GATEWAY_URL}/system/tag-providers` for tag provider list (fall back to empty array)
+- Check for existing scaffolded components (`ignition/script-python/testing/runner/`, `com.inductiveautomation.webdev/resources/testing/`, `e2e/package.json`, `.ignition-stubs/testing/`)
+- Output JSON to stdout
+
+```bash
+#!/usr/bin/env bash
+# detect-project.sh — Auto-detect Ignition project structure and gateway state.
+# Usage: detect-project.sh [project-directory]
+# Outputs JSON with project metadata, gateway status, and existing test infrastructure.
+
+set -euo pipefail
+
+TARGET="${1:-$PWD}"
+
+# Walk up to find project.json
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$TARGET") || {
+  echo '{"error": "No project.json found walking up from '"$TARGET"'"}' >&2
+  exit 1
+}
+
+PROJECT_NAME=$(basename "$PROJECT_ROOT")
+PROJECT_TITLE=$(jq -r '.title // ""' "$PROJECT_ROOT/project.json" 2>/dev/null || echo "")
+
+# Probe gateway
+GATEWAY_URL=""
+GATEWAY_REACHABLE=false
+
+for url in "https://localhost:9043" "http://localhost:8088"; do
+  if curl -k -s --connect-timeout 3 "$url/StatusPing" > /dev/null 2>&1; then
+    GATEWAY_URL="$url"
+    GATEWAY_REACHABLE=true
+    break
+  fi
+done
+
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+
+# Detect tag providers
+TAG_PROVIDERS="[]"
+if [ "$GATEWAY_REACHABLE" = true ]; then
+  TAG_PROVIDERS=$(curl -k -s --connect-timeout 3 "$GATEWAY_URL/system/tag-providers" 2>/dev/null || echo "[]")
+  # Validate it's JSON array
+  if ! echo "$TAG_PROVIDERS" | jq -e 'type == "array"' > /dev/null 2>&1; then
+    TAG_PROVIDERS="[]"
+  fi
+fi
+
+# Check for modules
+HAS_PERSPECTIVE=false
+HAS_WEBDEV=false
+HAS_SCRIPTING=false
+[ -d "$PROJECT_ROOT/com.inductiveautomation.perspective" ] && HAS_PERSPECTIVE=true
+[ -d "$PROJECT_ROOT/com.inductiveautomation.webdev" ] && HAS_WEBDEV=true
+[ -d "$PROJECT_ROOT/ignition/script-python" ] && HAS_SCRIPTING=true
+
+# Check existing test infrastructure
+HAS_JYTHON_FRAMEWORK=false
+HAS_WEBDEV_ENDPOINTS=false
+HAS_E2E=false
+HAS_STUBS=false
+[ -d "$PROJECT_ROOT/ignition/script-python/testing/runner" ] && HAS_JYTHON_FRAMEWORK=true
+[ -d "$PROJECT_ROOT/com.inductiveautomation.webdev/resources/testing/run" ] && HAS_WEBDEV_ENDPOINTS=true
+[ -f "$PROJECT_ROOT/e2e/package.json" ] && HAS_E2E=true
+[ -d "$PROJECT_ROOT/.ignition-stubs/testing" ] && HAS_STUBS=true
+
+jq -n \
+  --arg project_root "$PROJECT_ROOT" \
+  --arg project_title "$PROJECT_TITLE" \
+  --arg project_name "$PROJECT_NAME" \
+  --arg gateway_url "$GATEWAY_URL" \
+  --argjson gateway_reachable "$GATEWAY_REACHABLE" \
+  --argjson has_perspective "$HAS_PERSPECTIVE" \
+  --argjson has_webdev "$HAS_WEBDEV" \
+  --argjson has_scripting "$HAS_SCRIPTING" \
+  --argjson tag_providers "$TAG_PROVIDERS" \
+  --argjson jython_framework "$HAS_JYTHON_FRAMEWORK" \
+  --argjson webdev_endpoints "$HAS_WEBDEV_ENDPOINTS" \
+  --argjson e2e "$HAS_E2E" \
+  --argjson stubs "$HAS_STUBS" \
+  '{
+    project_root: $project_root,
+    project_title: $project_title,
+    project_name: $project_name,
+    gateway_url: $gateway_url,
+    gateway_reachable: $gateway_reachable,
+    has_perspective: $has_perspective,
+    has_webdev: $has_webdev,
+    has_scripting: $has_scripting,
+    tag_providers: $tag_providers,
+    existing_testing: {
+      jython_framework: $jython_framework,
+      webdev_endpoints: $webdev_endpoints,
+      e2e: $e2e,
+      stubs: $stubs
+    }
+  }'
+```
+
+- [ ] **Step 2: Make executable and test**
+
+Run: `chmod +x claude-code-plugin/scripts/detect-project.sh`
+
+Test against WHK-Global (should detect everything):
+```bash
+claude-code-plugin/scripts/detect-project.sh ~/data/projects/WHK-Global
+```
+
+Expected: JSON output with `project_name: "WHK-Global"`, `has_perspective: true`, `existing_testing.jython_framework: true`, etc.
+
+Test against a non-Ignition directory:
+```bash
+claude-code-plugin/scripts/detect-project.sh /tmp
+```
+
+Expected: Error message about no project.json found.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add claude-code-plugin/scripts/detect-project.sh
+git commit -m "feat(plugin): add detect-project.sh auto-detection script"
+```
+
+---
+
+## Task 2: Scaffold Testing Script
+
+**Files:**
+- Create: `claude-code-plugin/scripts/scaffold-testing.sh`
+
+**Source:** Genericize from WHK-Global's:
+- `ignition/script-python/testing/` (5 modules: runner, assertions, decorators, helpers, reporter)
+- `com.inductiveautomation.webdev/resources/testing/` (2 endpoints: run, tags)
+- `.ignition-stubs/testing/` (5 .pyi files)
+
+- [ ] **Step 1: Write scaffold-testing.sh**
+
+Create the script with these specifications:
+
+**Arguments:** `--project-root`, `--project-name`, `--gateway-url`, `--tag-provider`, `--force`, `--dry-run`
+
+**Genericizations from WHK-Global originals:**
+
+1. **runner/code.py** — Replace hardcoded paths:
+   - `/usr/local/bin/ignition/data/projects/WHK-Global/...` → `/usr/local/bin/ignition/data/projects/${PROJECT_NAME}/...`
+   - `/Users/pmannion/data/projects/WHK-Global/...` → Use actual `PROJECT_ROOT` variable set at top of file
+   - Add a `# Configuration` section at top: `PROJECT_NAME = "PLACEHOLDER"` (replaced by scaffold script with `sed`)
+
+2. **assertions/code.py** — Use as-is from WHK-Global (fully generic already)
+
+3. **decorators/code.py** — Use as-is from WHK-Global (fully generic already)
+
+4. **helpers/code.py** — Drop `run_process_queue()` and `_run_process_queue_direct()` (WHK-specific business logic). Keep only:
+   - `write_dataset_tag(tag_path, columns, types, rows)`
+   - `clear_dataset_tag(tag_path, columns, types)`
+
+5. **reporter/code.py** — Use as-is from WHK-Global (fully generic already)
+
+6. **WebDev run/doGet.py** — Replace `"WHK-Global Test Runner"` with `"${PROJECT_NAME} Test Runner"` (sed replacement)
+
+7. **WebDev run/doPost.py** — Use as-is (fully generic already — references `testing.runner` and `testing.reporter` which are module-relative)
+
+8. **WebDev tags/doGet.py** — Replace hardcoded `[WHK01]` tag path in simulatorCsv section with `[${TAG_PROVIDER}]`. Replace `'WHK_Sim_program.csv'` filename with `'${PROJECT_NAME}_Sim_program.csv'`
+
+9. **WebDev tags/doPost.py** — Replace hardcoded `/usr/local/bin/ignition/data/projects/WHK-Global` in importTags section. Drop the `mirror` handler that calls `general.tools.conversions.convert_to_memory_tags` (that's a WHK-specific script). Keep: writes, reads, script, deleteTags, importTags (with parameterized path)
+
+10. **config.json** — Use as-is (identical for both endpoints)
+
+11. **resource.json** — Use as-is (identical for all 5 modules)
+
+12. **.pyi stubs** — Use as-is from WHK-Global stubs, minus the `run_process_queue` and `_run_process_queue_direct` entries in helpers.pyi
+
+**Structure:**
+- Parse args with `while` loop and `case` statement
+- For each file: check if it exists (skip unless `--force`), create parent dirs with `mkdir -p`, write content with heredoc
+- `--dry-run` prints what would be created without writing
+- Track created/skipped counts, report at end
+
+The script will be large (~800-1000 lines) due to heredoc file content. This is expected and intentional — the entire Jython framework is embedded.
+
+- [ ] **Step 2: Make executable and test**
+
+Test with dry-run against a temp directory:
+```bash
+mkdir -p /tmp/test-ignition-project
+echo '{"title":"Test","enabled":true}' > /tmp/test-ignition-project/project.json
+mkdir -p /tmp/test-ignition-project/ignition/script-python
+mkdir -p /tmp/test-ignition-project/com.inductiveautomation.webdev/resources
+
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/test-ignition-project \
+  --project-name Test \
+  --gateway-url https://localhost:9043 \
+  --tag-provider default \
+  --dry-run
+```
+
+Expected: List of files that would be created.
+
+Test actual creation:
+```bash
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/test-ignition-project \
+  --project-name Test \
+  --gateway-url https://localhost:9043 \
+  --tag-provider default
+```
+
+Expected: All files created. Verify:
+- `runner/code.py` contains `PROJECT_NAME = "Test"` (not `WHK-Global`)
+- `helpers/code.py` does NOT contain `run_process_queue`
+- `doGet.py` shows `"Test Test Runner"`
+- `config.json` has `require-auth: false`
+
+Test idempotency:
+```bash
+# Run again — should skip all files
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/test-ignition-project \
+  --project-name Test \
+  --gateway-url https://localhost:9043 \
+  --tag-provider default
+```
+
+Expected: All files skipped.
+
+Clean up: `rm -rf /tmp/test-ignition-project`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add claude-code-plugin/scripts/scaffold-testing.sh
+git commit -m "feat(plugin): add scaffold-testing.sh for Jython test framework"
+```
+
+---
+
+## Task 3: Scaffold E2E Script
+
+**Files:**
+- Create: `claude-code-plugin/scripts/scaffold-e2e.sh`
+
+**Source:** Genericize from WHK-Global's `e2e/` directory.
+
+- [ ] **Step 1: Write scaffold-e2e.sh**
+
+**Arguments:** `--project-root`, `--project-name`, `--gateway-url`, `--tag-provider`, `--perspective-project`, `--force`, `--dry-run`
+
+**Genericizations from WHK-Global originals:**
+
+1. **package.json** — Change `"name"` from `"whk-global-e2e"` to `"${PROJECT_NAME_LOWER}-e2e"` (lowercase). Keep same deps and scripts.
+
+2. **tsconfig.json** — Use as-is (fully generic)
+
+3. **playwright.config.ts** — Remove the `api` project block. Keep `setup` and `chromium` only. Replace hardcoded `QSI_WhiskeyHouseKentucky01` with env var reference (already uses `process.env.PERSPECTIVE_PROJECT`).
+
+4. **.env.example** — Template with `IGNITION_URL`, `IGNITION_USER`, `IGNITION_PASSWORD`, `PERSPECTIVE_PROJECT=${PERSPECTIVE_PROJECT}`, `TAG_PROVIDER=${TAG_PROVIDER}`. Drop all MES/WMS vars.
+
+5. **.gitignore** — `node_modules/`, `test-results/`, `playwright-report/`, `.auth/`, `.env`, `dist/`, `.playwright-running.lock`
+
+6. **fixtures/auth.setup.ts** — Use as-is (already uses env vars, generic login detection)
+
+7. **fixtures/perspective.ts** — Use as-is (fully generic)
+
+8. **helpers/gateway-api.ts** — Drop everything below line 176 (MES, WMS, changeover tags, GraphQL sections). Replace hardcoded `WHK-Global` in `WEBDEV` constant with `process.env.IGNITION_PROJECT_NAME || "PROJECT_NAME_PLACEHOLDER"` (sed-replaced by script). Keep: `post()`, `get()`, tag operations, mirror operations, script invocation, health checks.
+
+9. **pages/PerspectivePage.ts** — Use as-is (already uses env var for project name)
+
+10. **components/PerspectiveComponent.ts, Button.ts, Table.ts** — Use as-is (fully generic)
+
+11. **tests/smoke/perspective-loads.spec.ts** — Rewrite to be generic:
+    - Keep "session loads and docks render" (universal)
+    - Drop "Cooker 1 page loads" (WHK-specific)
+    - Drop "top dock renders with plant instrumentation" (WHK-specific)
+    - Drop "Changeover Dashboard loads" (WHK-specific, imports ChangeoverDashboard)
+    - Drop "left dock menu tree" (WHK-specific labels)
+    - Add generic tests: "session loads", "page content renders components", "navigation exists in DOM"
+
+Same structure as scaffold-testing.sh: parse args, heredoc files, dry-run support, idempotent.
+
+- [ ] **Step 2: Make executable and test**
+
+Test with dry-run, then actual creation against temp directory. Verify:
+- `gateway-api.ts` does NOT contain `mesLogin`, `wmsLogin`, `CHANGEOVER_TAGS`, `changeoverGet`
+- `gateway-api.ts` DOES contain `readTags`, `writeTags`, `callScript`, `isGatewayReachable`
+- `.env.example` does NOT contain `MES_HOST` or `WMS_HOST`
+- `playwright.config.ts` does NOT have `api` project
+- Smoke tests do NOT import `ChangeoverDashboard`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add claude-code-plugin/scripts/scaffold-e2e.sh
+git commit -m "feat(plugin): add scaffold-e2e.sh for Playwright test setup"
+```
+
+---
+
+## Task 4: Hook Scripts
+
+**Files:**
+- Create: `claude-code-plugin/scripts/run-tests.sh`
+- Create: `claude-code-plugin/scripts/run-ui-tests.sh`
+
+- [ ] **Step 1: Write run-tests.sh**
+
+Post-commit gateway test runner. Based on WHK-Global's `.claude/hooks/run-tests.sh` with these changes:
+- Derive `PROJECT_NAME` from directory name (not hardcoded)
+- Gateway URL from `$IGNITION_GATEWAY_URL` env var, or `.env` in project root, or fallback `https://localhost:9043`
+- API token from `$IGNITION_API_TOKEN_FILE` env var (not hardcoded path)
+- Command matching: `[[ "$COMMAND" =~ git\ commit($|\ ) ]]`
+- Poll-based scan wait (5 iterations × 1s) instead of `sleep 3`
+- Self-gating: exit 0 if no `project.json` or no `testing/run` WebDev endpoint
+
+```bash
+#!/usr/bin/env bash
+# run-tests.sh — Post-commit gateway test hook
+# Triggers gateway scan, runs Jython tests, reports results.
+# Self-gates: silently exits if not in an Ignition project or test infra missing.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Only trigger on git commit
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+if [[ ! "$COMMAND" =~ git\ commit($|\ ) ]]; then
+  exit 0
+fi
+
+# Check commit succeeded
+STDOUT=$(echo "$INPUT" | jq -r '.tool_result.stdout // empty')
+if [[ ! "$STDOUT" =~ create\ mode|file\ changed|files\ changed|insertions|deletions ]] && [[ ! "$STDOUT" =~ \[ ]]; then
+  exit 0
+fi
+
+# Find project root
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$PWD") || exit 0
+PROJECT_NAME=$(basename "$PROJECT_ROOT")
+
+# Check test infrastructure exists
+if [ ! -d "$PROJECT_ROOT/com.inductiveautomation.webdev/resources/testing/run" ]; then
+  exit 0
+fi
+
+# Gateway URL
+GATEWAY_URL="${IGNITION_GATEWAY_URL:-}"
+if [ -z "$GATEWAY_URL" ] && [ -f "$PROJECT_ROOT/e2e/.env" ]; then
+  GATEWAY_URL=$(grep -E '^IGNITION_URL=' "$PROJECT_ROOT/e2e/.env" 2>/dev/null | cut -d= -f2- || true)
+fi
+GATEWAY_URL="${GATEWAY_URL:-https://localhost:9043}"
+
+# Check gateway reachable
+if ! curl -k -s --connect-timeout 3 "$GATEWAY_URL/StatusPing" > /dev/null 2>&1; then
+  exit 0
+fi
+
+# Trigger project scan (optional — requires API token)
+TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
+if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
+  TOKEN=$(cat "$TOKEN_FILE")
+  curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+    "$GATEWAY_URL/data/project-scan-endpoint/scan?updateDesigners=true" > /dev/null 2>&1 || true
+fi
+
+# Wait for scan propagation (best-effort, max 5s)
+for i in 1 2 3 4 5; do
+  sleep 1
+  curl -k -s --connect-timeout 2 "$GATEWAY_URL/StatusPing" > /dev/null 2>&1 && break
+done
+
+# Run tests
+ENDPOINT="$GATEWAY_URL/system/webdev/$PROJECT_NAME/testing/run"
+RESULT=$(curl -k -s -X POST "$ENDPOINT" 2>/dev/null) || exit 0
+
+# Parse results
+PASSED=$(echo "$RESULT" | jq -r '.passed // 0')
+FAILED=$(echo "$RESULT" | jq -r '.failed // 0')
+ERRORS=$(echo "$RESULT" | jq -r '.errors // 0')
+SKIPPED=$(echo "$RESULT" | jq -r '.skipped // 0')
+TOTAL=$(echo "$RESULT" | jq -r '.total // 0')
+DURATION=$(echo "$RESULT" | jq -r '.duration_ms // 0')
+
+if [ "$FAILED" -eq 0 ] && [ "$ERRORS" -eq 0 ]; then
+  echo "Tests: $PASSED passed, $SKIPPED skipped ($TOTAL total, ${DURATION}ms)" >&2
+else
+  echo "TESTS FAILED: $PASSED passed, $FAILED failed, $ERRORS errors ($TOTAL total, ${DURATION}ms)" >&2
+  echo "$RESULT" | jq -r '
+    .modules[]?.results[]? |
+    select(.status == "failed" or .status == "error") |
+    "  \(.status | ascii_upcase): \(.name) — \(.message)"
+  ' 2>/dev/null >&2 || true
+fi
+
+exit 0
+```
+
+- [ ] **Step 2: Write run-ui-tests.sh**
+
+Post-edit Playwright hook. Based on WHK-Global's `.claude/hooks/run-ui-tests.sh` with these changes:
+- Find `e2e/` relative to project root (not hardcoded)
+- Add `mkdir`-based concurrency guard
+- Self-gating checks
+
+```bash
+#!/usr/bin/env bash
+# run-ui-tests.sh — Post-edit Playwright hook for Perspective view changes.
+# Self-gates: silently exits if not editing a view.json or e2e not set up.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Only trigger on view.json edits
+case "$FILE_PATH" in
+  */view.json) ;;
+  *) exit 0 ;;
+esac
+
+# Must be a Perspective view
+if [[ "$FILE_PATH" != *"com.inductiveautomation.perspective/views/"* ]]; then
+  exit 0
+fi
+
+# Find project root
+find_project_root() {
+  local dir="$1"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/project.json" ]; then echo "$dir"; return 0; fi
+    dir=$(dirname "$dir")
+  done
+  return 1
+}
+
+PROJECT_ROOT=$(find_project_root "$(dirname "$FILE_PATH")") || exit 0
+E2E_DIR="$PROJECT_ROOT/e2e"
+
+# Silent exit if e2e not set up
+[ -d "$E2E_DIR/node_modules" ] || exit 0
+[ -f "$E2E_DIR/.auth/user.json" ] || exit 0
+
+# Concurrency guard (portable mkdir lock)
+LOCK_DIR="$E2E_DIR/.playwright-running.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  exit 0
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+# Extract view area for scoped testing
+VIEW_AREA=$(echo "$FILE_PATH" | sed -n 's|.*views/\([^/]*\)/.*|\1|p')
+VIEW_AREA_LOWER=$(echo "$VIEW_AREA" | tr '[:upper:]' '[:lower:]')
+
+TEST_DIR="$E2E_DIR/tests/$VIEW_AREA_LOWER"
+
+cd "$E2E_DIR"
+if [ -d "$TEST_DIR" ]; then
+  npx playwright test "$TEST_DIR" --reporter=list 2>&1 | tail -5 >&2 || true
+else
+  npx playwright test tests/smoke/ --reporter=list 2>&1 | tail -5 >&2 || true
+fi
+
+exit 0
+```
+
+- [ ] **Step 3: Make both executable**
+
+```bash
+chmod +x claude-code-plugin/scripts/run-tests.sh claude-code-plugin/scripts/run-ui-tests.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add claude-code-plugin/scripts/run-tests.sh claude-code-plugin/scripts/run-ui-tests.sh
+git commit -m "feat(plugin): add post-commit and post-edit test hook scripts"
+```
+
+---
+
+## Task 5: Update hooks.json
+
+**Files:**
+- Modify: `claude-code-plugin/hooks/hooks.json`
+
+- [ ] **Step 1: Update hooks.json**
+
+Replace the current single-hook config with the full three-hook config from the spec:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ignition-lint.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-ui-tests.sh",
+            "timeout": 120
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add claude-code-plugin/hooks/hooks.json
+git commit -m "feat(plugin): register gateway test and UI test hooks"
+```
+
+---
+
+## Task 6: Skills — init-testing
+
+**Files:**
+- Create: `claude-code-plugin/skills/init-testing/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md**
+
+```markdown
+---
+description: Scaffold the Jython test framework, WebDev test endpoints, and type stubs into an Ignition project. Usage — /ignition-scada:init-testing [--all] [--force]
+---
+
+# Initialize Ignition Testing
+
+Scaffold a complete Jython test framework into the current Ignition project. This creates:
+- **testing/** script library (runner, assertions, decorators, helpers, reporter)
+- **WebDev endpoints** for running tests and manipulating tags (`testing/run`, `testing/tags`)
+- **Type stubs** for IDE completion (`.ignition-stubs/testing/`)
+
+## Steps
+
+1. Run the detection script to discover project context:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Parse the JSON output and present findings to the user:
+   - Project name and location
+   - Gateway URL and reachability
+   - Tag providers (if detected)
+   - Any existing test infrastructure
+
+3. Ask the user to confirm or provide their tag provider name.
+
+4. If `existing_testing.jython_framework` or `existing_testing.webdev_endpoints` is true, warn the user and ask if they want to overwrite (`--force`).
+
+5. Run the scaffold script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-testing.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed>
+   ```
+   Add `--force` if user confirmed overwrite.
+
+6. Report what was created (list the files).
+
+7. If the gateway is reachable, verify the setup by hitting the test discovery endpoint:
+   ```bash
+   curl -k -s "https://localhost:9043/system/webdev/<project>/testing/run?discover=true"
+   ```
+   Note: This requires a gateway project scan first. Tell the user to scan from Designer or commit + push if using ignition-git-module.
+
+8. Explain how to write a first test:
+   - Create `ignition/script-python/<package>/__tests__/code.py`
+   - Import `from testing.decorators import test` and `from testing.assertions import assert_equal`
+   - Write `@test` decorated functions
+   - Run from Script Console: `print testing.runner.run_all()`
+
+If `$ARGUMENTS` contains `--all` and the project has Perspective (`has_perspective` is true), automatically proceed to run the `/ignition-scada:init-e2e` flow after completing the testing setup.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add claude-code-plugin/skills/init-testing/SKILL.md
+git commit -m "feat(plugin): add init-testing skill for Jython framework scaffolding"
+```
+
+---
+
+## Task 7: Skills — init-e2e
+
+**Files:**
+- Create: `claude-code-plugin/skills/init-e2e/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md**
+
+```markdown
+---
+description: Scaffold Playwright e2e tests for Perspective views into an Ignition project. Usage — /ignition-scada:init-e2e [--force]
+---
+
+# Initialize E2E Tests
+
+Scaffold a complete Playwright e2e test setup for Perspective views. This creates:
+- **e2e/** directory with Playwright config, auth fixtures, and TypeScript setup
+- **Page objects** for Perspective views (PerspectivePage base class)
+- **Component wrappers** (Button, Table, PerspectiveComponent)
+- **Gateway API helper** for tag read/write, script invocation, and health checks
+- **Smoke tests** that verify session loading and basic rendering
+
+## Steps
+
+1. Run the detection script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Check `has_perspective` — if false, warn the user: "No Perspective module found (`com.inductiveautomation.perspective/` directory missing). E2E tests require Perspective views. Continue anyway?"
+
+3. Present findings and ask the user to confirm their tag provider.
+
+4. Auto-detect the Perspective project name:
+   - If the gateway is reachable, the Perspective project name is typically the Ignition project name
+   - Check environment for `PERSPECTIVE_PROJECT` variable
+   - Ask the user to confirm the Perspective project name
+
+5. Ask the user to confirm the Perspective project name.
+
+6. Check if the Jython test framework exists (`existing_testing.jython_framework`). If not, inform the user and automatically run the testing scaffold first:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-testing.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed>
+   ```
+   The e2e gateway-api helper depends on the WebDev `testing/tags` endpoint.
+
+7. Run the e2e scaffold script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/scaffold-e2e.sh \
+     --project-root <detected> \
+     --project-name <detected> \
+     --gateway-url <detected> \
+     --tag-provider <confirmed> \
+     --perspective-project <confirmed>
+   ```
+
+8. Install dependencies:
+   ```bash
+   cd <project-root>/e2e && npm install && npx playwright install chromium
+   ```
+
+9. Tell the user to set up credentials:
+   - Copy `e2e/.env.example` to `e2e/.env`
+   - Fill in `IGNITION_USER` and `IGNITION_PASSWORD`
+
+10. Explain auth setup:
+    - Run `cd e2e && npx playwright test --project=setup` to authenticate
+    - Run `npm test` to run the smoke tests
+    - Run `npx playwright show-report` to view results in a browser
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add claude-code-plugin/skills/init-e2e/SKILL.md
+git commit -m "feat(plugin): add init-e2e skill for Playwright scaffolding"
+```
+
+---
+
+## Task 8: Skills — test
+
+**Files:**
+- Create: `claude-code-plugin/skills/test/SKILL.md`
+
+- [ ] **Step 1: Write SKILL.md**
+
+```markdown
+---
+description: Run Jython gateway tests or Playwright e2e tests. Usage — /ignition-scada:test [module|package|ui|e2e|smoke]
+---
+
+# Run Tests
+
+Run tests for the current Ignition project. Routes to gateway tests (Jython) or browser tests (Playwright) based on arguments.
+
+## Arguments
+
+`$ARGUMENTS`
+
+## Routing
+
+| Argument | Action |
+|----------|--------|
+| *(empty)* | Run all gateway Jython tests |
+| `<short-name>` (e.g. `changeover`) | Translate to module path and run: try `<name>.__tests__` first, search for matching module |
+| `<dotted.path>` (contains `.`) | Run as module or package filter |
+| `ui` or `e2e` | Run all Playwright tests |
+| `ui <area>` | Run Playwright tests in `e2e/tests/<area>/` |
+| `smoke` | Run `e2e/tests/smoke/` |
+
+## Gateway Tests
+
+1. Detect the project using the detect-project script:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/scripts/detect-project.sh
+   ```
+
+2. Check that test infrastructure exists (`existing_testing.jython_framework` and `existing_testing.webdev_endpoints`). If not, tell the user: "Test infrastructure not found. Run `/ignition-scada:init-testing` first."
+
+3. Trigger a gateway project scan (if API token is available):
+   ```bash
+   TOKEN_FILE="${IGNITION_API_TOKEN_FILE:-}"
+   if [ -n "$TOKEN_FILE" ] && [ -f "$TOKEN_FILE" ]; then
+     TOKEN=$(cat "$TOKEN_FILE")
+     curl -k -s -X POST -H "X-Ignition-API-Token: $TOKEN" \
+       "<gateway>/data/project-scan-endpoint/scan?updateDesigners=true"
+   fi
+   ```
+
+4. Wait 3-5 seconds for scan propagation.
+
+5. Run the tests:
+   ```bash
+   # All tests
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run"
+
+   # Specific module
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run?module=<module>"
+
+   # Package filter
+   curl -k -s -X POST "<gateway>/system/webdev/<project>/testing/run?package=<package>"
+   ```
+
+6. Parse the JSON response and present results:
+   - Summary: total, passed, failed, skipped, errors, duration
+   - On failure: show each failure with test name, error message, and traceback
+   - On success: report concisely
+
+## Playwright Tests
+
+1. Check that `e2e/node_modules` exists. If not, tell the user to run `cd e2e && npm install && npx playwright install chromium`.
+
+2. Check that `e2e/.auth/user.json` exists. If not, tell the user to run `cd e2e && npx playwright test --project=setup`.
+
+3. Run the tests:
+   ```bash
+   # All e2e tests
+   cd e2e && npx playwright test
+
+   # Specific area
+   cd e2e && npx playwright test tests/<area>/
+
+   # Smoke only
+   cd e2e && npx playwright test tests/smoke/
+
+   # Add --headed if user says "headed" or "watch"
+   ```
+
+4. Parse the output and report results.
+
+5. On failure, suggest: `cd e2e && npx playwright show-report`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add claude-code-plugin/skills/test/SKILL.md
+git commit -m "feat(plugin): add test skill for running gateway and e2e tests"
+```
+
+---
+
+## Task 9: Plugin Manifest and README
+
+**Files:**
+- Modify: `claude-code-plugin/.claude-plugin/plugin.json`
+- Modify: `claude-code-plugin/README.md`
+
+- [ ] **Step 1: Update plugin.json**
+
+Bump version to `0.2.0` and update description:
+
+```json
+{
+  "name": "ignition-scada",
+  "description": "Ignition SCADA development — API reference, expression language, auto-linting, test scaffolding, and automated testing for Ignition projects",
+  "version": "0.2.0",
+  "author": {
+    "name": "Whiskey House",
+    "url": "https://github.com/whiskeyhouse"
+  },
+  "homepage": "https://github.com/whiskeyhouse/ignition-nvim",
+  "repository": "https://github.com/whiskeyhouse/ignition-nvim",
+  "license": "MIT",
+  "keywords": ["ignition", "scada", "ics", "inductive-automation", "jython", "plc", "testing", "playwright"],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
+}
+```
+
+- [ ] **Step 2: Update README.md**
+
+Add a Testing section after the existing content. Cover:
+- What the testing features provide (Jython framework, e2e, hooks)
+- Quick start: `/ignition-scada:init-testing --all`
+- Running tests: `/ignition-scada:test`, `/ignition-scada:test ui`
+- Deterministic mode: direct shell script usage
+- Prerequisites: Node.js for e2e, `jq` for detection
+- What the plugin scaffolds (file tree)
+- What the hooks do automatically
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add claude-code-plugin/.claude-plugin/plugin.json claude-code-plugin/README.md
+git commit -m "feat(plugin): bump to v0.2.0 with testing integration"
+```
+
+---
+
+## Task 10: End-to-End Verification
+
+- [ ] **Step 1: Verify plugin structure**
+
+```bash
+find claude-code-plugin -type f | sort
+```
+
+Expected: All files from the file map exist.
+
+- [ ] **Step 2: Test detect-project.sh against WHK-Global**
+
+```bash
+claude-code-plugin/scripts/detect-project.sh ~/data/projects/WHK-Global
+```
+
+Expected: Complete JSON with all fields populated.
+
+- [ ] **Step 3: Test scaffold scripts with --dry-run**
+
+```bash
+mkdir -p /tmp/verify-plugin
+echo '{"title":"Verify","enabled":true}' > /tmp/verify-plugin/project.json
+mkdir -p /tmp/verify-plugin/ignition/script-python
+mkdir -p /tmp/verify-plugin/com.inductiveautomation.webdev/resources
+mkdir -p /tmp/verify-plugin/com.inductiveautomation.perspective/views
+
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/verify-plugin \
+  --project-name Verify \
+  --gateway-url https://localhost:9043 \
+  --tag-provider VFY01 \
+  --dry-run
+
+claude-code-plugin/scripts/scaffold-e2e.sh \
+  --project-root /tmp/verify-plugin \
+  --project-name Verify \
+  --gateway-url https://localhost:9043 \
+  --tag-provider VFY01 \
+  --perspective-project QSI_Verify \
+  --dry-run
+```
+
+- [ ] **Step 4: Test full scaffold**
+
+```bash
+claude-code-plugin/scripts/scaffold-testing.sh \
+  --project-root /tmp/verify-plugin \
+  --project-name Verify \
+  --gateway-url https://localhost:9043 \
+  --tag-provider VFY01
+
+claude-code-plugin/scripts/scaffold-e2e.sh \
+  --project-root /tmp/verify-plugin \
+  --project-name Verify \
+  --gateway-url https://localhost:9043 \
+  --tag-provider VFY01 \
+  --perspective-project QSI_Verify
+
+# Verify key substitutions
+grep "PROJECT_NAME" /tmp/verify-plugin/ignition/script-python/testing/runner/code.py
+grep "VFY01" /tmp/verify-plugin/e2e/.env.example
+grep "QSI_Verify" /tmp/verify-plugin/e2e/.env.example
+```
+
+- [ ] **Step 5: Test hook scripts with mock input**
+
+```bash
+# Test run-tests.sh exits silently on non-commit
+echo '{"tool_input":{"command":"git status"},"tool_result":{"stdout":""}}' | \
+  claude-code-plugin/scripts/run-tests.sh
+
+# Test run-ui-tests.sh exits silently on non-view file
+echo '{"tool_input":{"file_path":"/tmp/foo.py"}}' | \
+  claude-code-plugin/scripts/run-ui-tests.sh
+```
+
+Both should exit 0 with no output.
+
+- [ ] **Step 6: Clean up and final commit**
+
+```bash
+rm -rf /tmp/verify-plugin
+```
+
+If any issues were found and fixed during verification, commit the fixes.

--- a/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
+++ b/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
@@ -124,7 +124,7 @@ com.inductiveautomation.webdev/resources/testing/
 e2e/
 ├── package.json              # @playwright/test, dotenv
 ├── tsconfig.json             # ES2022, NodeNext, path aliases
-├── playwright.config.ts      # Projects: setup, chromium, api
+├── playwright.config.ts      # Projects: setup, chromium
 ├── .env.example              # Template with all config vars
 ├── .gitignore                # node_modules, test-results, .auth, .env
 ├── fixtures/
@@ -177,10 +177,10 @@ Supports `--all` flag: after scaffolding testing, automatically runs `init-e2e` 
 
 1. Run `detect-project.sh`
 2. Check `has_perspective` — if false, warn: "No Perspective module found. E2E tests require Perspective views. Continue anyway?"
-3. Check `existing_testing.jython_framework` — if false, inform the user and automatically call `scaffold-testing.sh` with the already-confirmed parameters (no second interactive confirmation — the tag provider was already confirmed in step 4). The e2e tests depend on the WebDev `testing/tags` endpoint for tag operations.
-4. Present findings, ask user to confirm tag provider
-5. Auto-detect Perspective project name: check for `com.inductiveautomation.perspective/` views, or if gateway reachable, query for running Perspective projects
-6. Ask user to confirm Perspective project name
+3. Present findings, ask user to confirm tag provider
+4. Auto-detect Perspective project name: check for `com.inductiveautomation.perspective/` views, or if gateway reachable, query for running Perspective projects
+5. Ask user to confirm Perspective project name
+6. Check `existing_testing.jython_framework` — if false, inform the user and automatically call `scaffold-testing.sh` with the confirmed parameters from step 3 (no second interactive confirmation). The e2e tests depend on the WebDev `testing/tags` endpoint for tag operations.
 7. Call `scaffold-e2e.sh` with confirmed parameters
 8. Run `cd e2e && npm install && npx playwright install chromium`
 9. Prompt user to set credentials: "Copy `e2e/.env.example` to `e2e/.env` and fill in `IGNITION_USER` and `IGNITION_PASSWORD`"
@@ -201,7 +201,7 @@ Routes based on arguments. Detects project context automatically.
 
 All test invocations:
 1. Trigger a gateway project scan first (to pick up recent file changes)
-2. Poll for scan completion: hit `StatusPing` up to 5 times at 1-second intervals (max 5s wait). This replaces the hardcoded 3-second sleep — faster for small projects, more reliable for large ones. If polling times out, proceed anyway (tests may use stale scripts but won't fail to run)
+2. Wait for scan propagation: poll up to 5 times at 1-second intervals (max 5s). This is a best-effort delay — Ignition has no scan-completion endpoint, so we use a simple timed wait that's more responsive than a hardcoded sleep. If the wait times out, proceed anyway (tests may use stale scripts but won't fail to run)
 3. Run the tests
 4. Parse and present results (summary + failure details)
 5. On missing infrastructure, suggest the appropriate init skill
@@ -213,7 +213,7 @@ Two new hook scripts in `scripts/`, plus the existing `ignition-lint.sh`:
 #### `scripts/run-tests.sh` — Post-commit gateway tests
 
 - **Trigger:** `PostToolUse` on `Bash` — filters for `git commit` commands
-- **Command matching:** Reads `tool_input.command` from hook JSON. Matches if the command string contains `git commit` (simple substring match via `[[ "$COMMAND" =~ "git commit" ]]`). This intentionally matches `git commit -m`, `git commit --amend`, etc. Also checks `tool_result.stdout` for commit success indicators (`file changed`, `insertions`, `deletions`, or branch ref like `[main abc1234]`) to avoid running tests on failed commits.
+- **Command matching:** Reads `tool_input.command` from hook JSON. Matches via bash regex `[[ "$COMMAND" =~ git\ commit($|\ ) ]]` — this matches `git commit`, `git commit -m "..."`, `git commit --amend`, etc. but not false positives like `git committed`. Also checks `tool_result.stdout` for commit success indicators (`file changed`, `insertions`, `deletions`, or branch ref like `[main abc1234]`) to avoid running tests on failed commits.
 - **Detection:** Walks up from cwd to find `project.json`, derives project name from directory
 - **Gateway URL:** Reads from `$IGNITION_GATEWAY_URL` env var, or `.env` in project root, or falls back to `https://localhost:9043`
 - **API token:** Reads from `$IGNITION_API_TOKEN_FILE` env var (no hardcoded path). Used for project scan trigger only. If no token file is set, scan trigger is skipped (tests still run against whatever scripts the gateway has loaded).
@@ -226,7 +226,7 @@ Two new hook scripts in `scripts/`, plus the existing `ignition-lint.sh`:
 - **Detection:** Finds `e2e/` relative to project root (not hardcoded path)
 - **Scoping:** Extracts view area from path (`views/{Area}/...`) → maps to `e2e/tests/{area}/`
 - **Fallback:** If no matching test directory, runs `e2e/tests/smoke/`
-- **Concurrency guard:** Uses a lockfile (`e2e/.playwright-running.lock`) with `flock` to prevent concurrent Playwright runs. If another test run is in progress, the hook silently exits. The lockfile is removed on completion (or by trap on exit).
+- **Concurrency guard:** Uses a lockfile directory (`e2e/.playwright-running.lock`) with `mkdir` as an atomic lock (portable across macOS and Linux — `flock` is Linux-only). If `mkdir` fails (lock exists), the hook silently exits. The lock directory is removed on completion via `trap ... EXIT`.
 - **Silent exit if:** `e2e/node_modules` doesn't exist, `.auth/user.json` doesn't exist, another test run is in progress, not a Perspective view.json
 
 **Performance note:** The self-gating check for `run-ui-tests.sh` is cheap — it reads `tool_input.file_path` from stdin, does a string match on `view.json`, checks two filesystem paths, and exits. This runs on every `Edit|Write` alongside `ignition-lint.sh`, but the early-exit path is ~5ms. The Playwright launch only happens for actual Perspective view edits.

--- a/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
+++ b/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
@@ -1,0 +1,320 @@
+# Plugin Testing Integration Design
+
+**Date:** 2026-03-24
+**Status:** Draft
+**Scope:** Integrate Jython gateway testing and Playwright e2e testing into the `ignition-scada` Claude Code plugin
+
+## Problem
+
+WHK-Global has a mature testing infrastructure — a Jython unit test framework that runs on the Ignition gateway, Playwright e2e tests for Perspective views, and Claude Code hooks that tie them together. But this infrastructure is bespoke to that one project. Every new Ignition project starts from zero.
+
+The `ignition-scada` Claude Code plugin already provides auto-linting, API reference, and expression language support. Extending it with test scaffolding means any Ignition developer gets a complete testing setup with one or two commands.
+
+## Decision: Option B + C Hybrid
+
+**Layered skills** for orchestration and context-awareness, backed by **deterministic shell scripts** for reproducibility. Skills call the scripts; users can also call the scripts directly without Claude.
+
+## Architecture
+
+### Detection Layer
+
+`scripts/detect-project.sh` — shared auto-detection script.
+
+**Inputs:** Optional project directory (defaults to walking up from `$PWD` looking for `project.json`).
+
+**Outputs JSON:**
+```json
+{
+  "project_root": "/path/to/project",
+  "project_title": "Global",
+  "project_name": "WHK-Global",
+  "gateway_url": "https://localhost:9043",
+  "gateway_reachable": true,
+  "has_perspective": true,
+  "has_webdev": true,
+  "has_scripting": true,
+  "tag_providers": ["WHK01", "default"],
+  "existing_testing": {
+    "jython_framework": false,
+    "webdev_endpoints": false,
+    "e2e": false,
+    "stubs": false
+  }
+}
+```
+
+**Detection logic:**
+- `project_root`: Walk up from target dir looking for `project.json`
+- `project_title`: Parse `project.json` → `.title`
+- `project_name`: Directory name containing `project.json`
+- `gateway_url`: Probe `https://localhost:9043/StatusPing`, fall back to `http://localhost:8088/StatusPing`
+- `gateway_reachable`: StatusPing returned 200
+- `has_perspective`: `com.inductiveautomation.perspective/` directory exists
+- `has_webdev`: `com.inductiveautomation.webdev/` directory exists
+- `has_scripting`: `ignition/script-python/` directory exists
+- `tag_providers`: If gateway reachable, query tag browse endpoint for provider list
+- `existing_testing`: Check for each scaffolded component
+
+When the gateway is unreachable, `tag_providers` is an empty array and `gateway_reachable` is false. Scaffolding still proceeds — tag provider becomes a placeholder in `.env.example`.
+
+**The skills present detection results to the user and ask them to confirm or correct the tag provider.** This is the one interactive step — everything else is automatic.
+
+### Scaffolding Scripts
+
+Two deterministic shell scripts that create files via heredocs. No LLM involved.
+
+#### `scripts/scaffold-testing.sh`
+
+**Inputs:** `--project-root`, `--project-name`, `--gateway-url`, `--tag-provider`
+**Flag:** `--force` to overwrite existing files (default: skip existing)
+
+**Creates:**
+
+```
+ignition/script-python/testing/
+├── runner/
+│   ├── code.py          # Test discovery and execution
+│   └── resource.json    # Ignition resource descriptor
+├── assertions/
+│   ├── code.py          # assert_equal, assert_true, assert_raises, etc.
+│   └── resource.json
+├── decorators/
+│   ├── code.py          # @test, @skip, @setup, @teardown, @expected_error
+│   └── resource.json
+├── helpers/
+│   ├── code.py          # Tag read/write helpers for integration tests
+│   └── resource.json
+└── reporter/
+    ├── code.py          # JSON, console, and JUnit XML formatters
+    └── resource.json
+
+com.inductiveautomation.webdev/resources/testing/
+├── run/
+│   ├── doGet.py         # GET: discover test modules
+│   ├── doPost.py        # POST: run tests (module, package, or all)
+│   └── config.json      # WebDev endpoint config (no auth required)
+└── tags/
+    ├── doGet.py         # GET: browse tags, export simulator CSV
+    ├── doPost.py        # POST: read/write/mirror tags, call scripts
+    └── config.json
+
+.ignition-stubs/testing/
+├── runner.pyi
+├── assertions.pyi
+├── decorators.pyi
+├── helpers.pyi
+└── reporter.pyi
+```
+
+**Key genericizations from WHK-Global:**
+- Runner discovery paths are parameterized: uses `PROJECT_NAME` variable instead of hardcoded `WHK-Global`
+- Runner checks both Docker path (`/usr/local/bin/ignition/data/projects/${PROJECT_NAME}/...`) and local dev path (the actual `project_root`)
+- Helpers drop WHK-specific `run_process_queue` — only generic tag operations remain
+- Tag endpoint's `_ensureTag` and data type inference are kept (universally useful)
+- WebDev endpoints use the project name in their URL path automatically (Ignition convention)
+
+#### `scripts/scaffold-e2e.sh`
+
+**Inputs:** `--project-root`, `--project-name`, `--gateway-url`, `--tag-provider`, `--perspective-project`
+**Flag:** `--force` to overwrite existing files
+
+**Creates:**
+
+```
+e2e/
+├── package.json              # @playwright/test, dotenv
+├── tsconfig.json             # ES2022, NodeNext, path aliases
+├── playwright.config.ts      # Projects: setup, chromium, api
+├── .env.example              # Template with all config vars
+├── .gitignore                # node_modules, test-results, .auth, .env
+├── fixtures/
+│   ├── auth.setup.ts         # Gateway authentication (login form detection)
+│   └── perspective.ts        # Custom PerspectivePage fixture
+├── helpers/
+│   └── gateway-api.ts        # Tag ops, health checks, script invocation
+├── pages/
+│   └── PerspectivePage.ts    # Base page object for Perspective views
+├── components/
+│   ├── PerspectiveComponent.ts  # Base component wrapper
+│   ├── Button.ts                # ia.input.button wrapper
+│   └── Table.ts                 # ia.display.table wrapper
+└── tests/
+    └── smoke/
+        └── perspective-loads.spec.ts  # Generic smoke tests
+```
+
+**Key genericizations from WHK-Global:**
+- `gateway-api.ts` drops MES-specific methods (`mesLogin`, `mesGraphQL`, `changeoverGet/Post`), WMS methods (`wmsLogin`, `wmsGet/Post`), and changeover tag helpers — these are WHK business logic
+- Keeps: tag read/write/mirror, script invocation, health checks, project scan trigger
+- `.env.example` has `IGNITION_URL`, `IGNITION_USER`, `IGNITION_PASSWORD`, `PERSPECTIVE_PROJECT`, `TAG_PROVIDER` — no MES/WMS vars
+- `playwright.config.ts` has `setup` and `chromium` projects only — no `api` project (that was WHK-specific test matching)
+- Smoke tests are generic: "session loads", "page renders components", "docks exist" — no references to specific WHK views like "Mash Cooker #1" or "Changeover Dashboard"
+- `PerspectivePage.ts` is kept as-is — its conventions (`data-component-path`, dock prefixes, WebSocket SPA behavior) are universal Perspective patterns
+- `auth.setup.ts` is kept as-is — the login form detection (`input.username-field`, `div.submit-button`) is standard Ignition IdP
+
+**Both scripts are idempotent.** They check for existing files before writing. With `--force`, they overwrite. Without it, they skip and report what was skipped.
+
+### Plugin Skills
+
+Three new user-invocable skills:
+
+#### `/ignition-scada:init-testing`
+
+1. Run `detect-project.sh` (from project root or cwd)
+2. Present findings: "Found project *{title}* at `{root}`, gateway at `{url}` ({reachable/unreachable}), tag providers: {list}"
+3. Ask user to confirm or provide tag provider
+4. Check `existing_testing.jython_framework` and `existing_testing.webdev_endpoints` — warn if already scaffolded, offer `--force`
+5. Call `scaffold-testing.sh` with confirmed parameters
+6. Report what was created
+7. If gateway reachable: run test discovery endpoint to verify setup works
+8. Explain how to write a first test: create `ignition/script-python/{package}/__tests__/code.py`, import decorators/assertions, write `@test` function
+
+Supports `--all` flag: after scaffolding testing, automatically runs `init-e2e` flow if the project has Perspective.
+
+#### `/ignition-scada:init-e2e`
+
+1. Run `detect-project.sh`
+2. Check `has_perspective` — if false, warn: "No Perspective module found. E2E tests require Perspective views. Continue anyway?"
+3. Check `existing_testing.jython_framework` — if false, run `init-testing` first (the e2e tests depend on the gateway API endpoint for tag operations and project scanning)
+4. Present findings, ask user to confirm tag provider
+5. Auto-detect Perspective project name: check for `com.inductiveautomation.perspective/` views, or if gateway reachable, query for running Perspective projects
+6. Ask user to confirm Perspective project name
+7. Call `scaffold-e2e.sh` with confirmed parameters
+8. Run `cd e2e && npm install && npx playwright install chromium`
+9. Prompt user to set credentials: "Copy `e2e/.env.example` to `e2e/.env` and fill in `IGNITION_USER` and `IGNITION_PASSWORD`"
+10. Explain auth setup: "Run `cd e2e && npx playwright test --project=setup` to authenticate, then `npm test` to run smoke tests"
+
+#### `/ignition-scada:test`
+
+Routes based on arguments. Detects project context automatically.
+
+| Invocation | Action |
+|------------|--------|
+| `/ignition-scada:test` | Run all gateway Jython tests |
+| `/ignition-scada:test {short-name}` | Translate to `{package}.{name}.__tests__` and run that module |
+| `/ignition-scada:test {dotted.path}` | Run as module or package filter |
+| `/ignition-scada:test ui` or `e2e` | Run all Playwright tests |
+| `/ignition-scada:test ui {area}` | Run `e2e/tests/{area}/` |
+| `/ignition-scada:test smoke` | Run `e2e/tests/smoke/` |
+
+All test invocations:
+1. Trigger a gateway project scan first (to pick up recent file changes)
+2. Wait 3 seconds for propagation
+3. Run the tests
+4. Parse and present results (summary + failure details)
+5. On missing infrastructure, suggest the appropriate init skill
+
+### Hook Scripts
+
+Two new hook scripts in `scripts/`, plus the existing `ignition-lint.sh`:
+
+#### `scripts/run-tests.sh` — Post-commit gateway tests
+
+- **Trigger:** `PostToolUse` on `Bash` — filters for `git commit` commands
+- **Detection:** Walks up from cwd to find `project.json`, derives project name from directory
+- **Gateway URL:** Reads from `$IGNITION_GATEWAY_URL` env var, or `.env` in project root, or falls back to `https://localhost:9043`
+- **API token:** Reads from `$IGNITION_API_TOKEN_FILE` env var (no hardcoded path)
+- **Flow:** Probe gateway → trigger scan → wait 3s → POST to `testing/run` → parse results → report summary to stderr
+- **Silent exit if:** Gateway unreachable, endpoint doesn't exist, commit failed
+
+#### `scripts/run-ui-tests.sh` — Post-edit Playwright tests
+
+- **Trigger:** `PostToolUse` on `Edit|Write` — filters for `*/view.json` under Perspective views
+- **Detection:** Finds `e2e/` relative to project root (not hardcoded path)
+- **Scoping:** Extracts view area from path (`views/{Area}/...`) → maps to `e2e/tests/{area}/`
+- **Fallback:** If no matching test directory, runs `e2e/tests/smoke/`
+- **Silent exit if:** `e2e/node_modules` doesn't exist, `.auth/user.json` doesn't exist
+
+#### Self-gating design
+
+All hooks are registered at the plugin level in `hooks/hooks.json`. They fire on every matching tool use across all projects. Each hook self-gates:
+
+1. Check if we're in an Ignition project (walk up for `project.json`)
+2. Check if the relevant infrastructure exists (testing endpoint, e2e directory)
+3. If either check fails, `exit 0` silently
+
+This means installing the plugin is safe before running any init skills. The hooks are dormant until the test infrastructure is scaffolded.
+
+### Updated `hooks/hooks.json`
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ignition-lint.sh",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-ui-tests.sh",
+            "timeout": 120
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/run-tests.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Final Plugin Structure
+
+```
+claude-code-plugin/
+├── .claude-plugin/
+│   └── plugin.json                    # v0.2.0
+├── hooks/
+│   └── hooks.json                     # 3 hooks: lint, gateway tests, UI tests
+├── scripts/
+│   ├── detect-project.sh              # NEW — auto-detection (shared)
+│   ├── scaffold-testing.sh            # NEW — Jython + WebDev scaffolding
+│   ├── scaffold-e2e.sh               # NEW — Playwright scaffolding
+│   ├── ignition-lint.sh              # EXISTING — auto-lint on edit
+│   ├── run-tests.sh                  # NEW — post-commit gateway tests
+│   └── run-ui-tests.sh              # NEW — post-edit Playwright tests
+├── skills/
+│   ├── ignition-api/SKILL.md         # EXISTING — system.* API reference
+│   ├── ignition-expressions/SKILL.md # EXISTING — expression language
+│   ├── ignition-lint/SKILL.md        # EXISTING — manual lint
+│   ├── init-testing/SKILL.md         # NEW — scaffold Jython + WebDev
+│   ├── init-e2e/SKILL.md            # NEW — scaffold Playwright
+│   └── test/SKILL.md                # NEW — run tests
+└── README.md                         # Updated with testing docs
+```
+
+### What the Plugin Does NOT Scaffold
+
+Business-logic test modules. The framework gives you `testing.*` and the endpoints. Writing actual tests (`core.mes.changeover.__tests__/code.py`) is the developer's job — the plugin just makes it easy to get started.
+
+Project-specific page objects. `PerspectivePage.ts` is the base. Specific page objects like `ChangeoverDashboard.ts` are project-specific and written by the developer as they build views.
+
+MES/WMS/domain-specific API helpers. The `gateway-api.ts` provides tag ops, script calls, and health checks. Domain integrations (GraphQL, REST APIs, OAuth flows) are added per-project.
+
+## Testing the Plugin Itself
+
+The scaffolding scripts can be tested by running them against a temp directory and validating the output file tree. No gateway needed — just check that the right files are created with the right content substitutions.
+
+The hook scripts can be tested by piping them mock JSON input (simulating Claude Code's hook protocol) and checking exit codes + stderr output.
+
+## Migration Path for WHK-Global
+
+Once the plugin ships, WHK-Global can:
+1. Install the plugin
+2. Delete `.claude/hooks/ignition-lint.sh`, `run-tests.sh`, `run-ui-tests.sh` (plugin hooks replace them)
+3. Delete `.claude/commands/test.md` (plugin `/ignition-scada:test` replaces it)
+4. Keep project-specific test modules, page objects, and domain helpers (those aren't in the plugin)
+5. Keep `.claude/settings.json` hooks section can be cleaned up (plugin hooks handle it)

--- a/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
+++ b/docs/superpowers/specs/2026-03-24-plugin-testing-integration-design.md
@@ -47,12 +47,12 @@ The `ignition-scada` Claude Code plugin already provides auto-linting, API refer
 - `project_root`: Walk up from target dir looking for `project.json`
 - `project_title`: Parse `project.json` → `.title`
 - `project_name`: Directory name containing `project.json`
-- `gateway_url`: Probe `https://localhost:9043/StatusPing`, fall back to `http://localhost:8088/StatusPing`
+- `gateway_url`: Probe `https://localhost:9043/StatusPing` then `http://localhost:8088/StatusPing` with `--connect-timeout 3` (3-second connection timeout to avoid hanging on unreachable gateways)
 - `gateway_reachable`: StatusPing returned 200
 - `has_perspective`: `com.inductiveautomation.perspective/` directory exists
 - `has_webdev`: `com.inductiveautomation.webdev/` directory exists
 - `has_scripting`: `ignition/script-python/` directory exists
-- `tag_providers`: If gateway reachable, query tag browse endpoint for provider list
+- `tag_providers`: If gateway reachable, query the built-in Ignition tag browse endpoint at `${GATEWAY_URL}/system/tag-providers` (no auth required, returns JSON array of provider names). If the endpoint is unavailable (older Ignition versions), fall back to browsing `${GATEWAY_URL}/system/webdev/${PROJECT_NAME}/testing/tags?browse=providers` if the WebDev endpoint exists, otherwise return empty array
 - `existing_testing`: Check for each scaffolded component
 
 When the gateway is unreachable, `tag_providers` is an empty array and `gateway_reachable` is false. Scaffolding still proceeds — tag provider becomes a placeholder in `.env.example`.
@@ -152,7 +152,9 @@ e2e/
 - `PerspectivePage.ts` is kept as-is — its conventions (`data-component-path`, dock prefixes, WebSocket SPA behavior) are universal Perspective patterns
 - `auth.setup.ts` is kept as-is — the login form detection (`input.username-field`, `div.submit-button`) is standard Ignition IdP
 
-**Both scripts are idempotent.** They check for existing files before writing. With `--force`, they overwrite. Without it, they skip and report what was skipped.
+**Both scripts are idempotent.** They check for existing files before writing. With `--force`, they overwrite. Without it, they skip and report what was skipped. Both also support `--dry-run` to preview what files would be created without writing anything.
+
+**Partial failure recovery:** If a script fails mid-execution (e.g., disk full, permission error), it leaves whatever files were successfully created. Re-running without `--force` recovers gracefully — it skips the already-created files and creates only the missing ones. The detection layer's `existing_testing` checks are granular enough to identify partial states (e.g., `jython_framework: true` but `webdev_endpoints: false`).
 
 ### Plugin Skills
 
@@ -175,7 +177,7 @@ Supports `--all` flag: after scaffolding testing, automatically runs `init-e2e` 
 
 1. Run `detect-project.sh`
 2. Check `has_perspective` — if false, warn: "No Perspective module found. E2E tests require Perspective views. Continue anyway?"
-3. Check `existing_testing.jython_framework` — if false, run `init-testing` first (the e2e tests depend on the gateway API endpoint for tag operations and project scanning)
+3. Check `existing_testing.jython_framework` — if false, inform the user and automatically call `scaffold-testing.sh` with the already-confirmed parameters (no second interactive confirmation — the tag provider was already confirmed in step 4). The e2e tests depend on the WebDev `testing/tags` endpoint for tag operations.
 4. Present findings, ask user to confirm tag provider
 5. Auto-detect Perspective project name: check for `com.inductiveautomation.perspective/` views, or if gateway reachable, query for running Perspective projects
 6. Ask user to confirm Perspective project name
@@ -199,7 +201,7 @@ Routes based on arguments. Detects project context automatically.
 
 All test invocations:
 1. Trigger a gateway project scan first (to pick up recent file changes)
-2. Wait 3 seconds for propagation
+2. Poll for scan completion: hit `StatusPing` up to 5 times at 1-second intervals (max 5s wait). This replaces the hardcoded 3-second sleep — faster for small projects, more reliable for large ones. If polling times out, proceed anyway (tests may use stale scripts but won't fail to run)
 3. Run the tests
 4. Parse and present results (summary + failure details)
 5. On missing infrastructure, suggest the appropriate init skill
@@ -211,11 +213,12 @@ Two new hook scripts in `scripts/`, plus the existing `ignition-lint.sh`:
 #### `scripts/run-tests.sh` — Post-commit gateway tests
 
 - **Trigger:** `PostToolUse` on `Bash` — filters for `git commit` commands
+- **Command matching:** Reads `tool_input.command` from hook JSON. Matches if the command string contains `git commit` (simple substring match via `[[ "$COMMAND" =~ "git commit" ]]`). This intentionally matches `git commit -m`, `git commit --amend`, etc. Also checks `tool_result.stdout` for commit success indicators (`file changed`, `insertions`, `deletions`, or branch ref like `[main abc1234]`) to avoid running tests on failed commits.
 - **Detection:** Walks up from cwd to find `project.json`, derives project name from directory
 - **Gateway URL:** Reads from `$IGNITION_GATEWAY_URL` env var, or `.env` in project root, or falls back to `https://localhost:9043`
-- **API token:** Reads from `$IGNITION_API_TOKEN_FILE` env var (no hardcoded path)
-- **Flow:** Probe gateway → trigger scan → wait 3s → POST to `testing/run` → parse results → report summary to stderr
-- **Silent exit if:** Gateway unreachable, endpoint doesn't exist, commit failed
+- **API token:** Reads from `$IGNITION_API_TOKEN_FILE` env var (no hardcoded path). Used for project scan trigger only. If no token file is set, scan trigger is skipped (tests still run against whatever scripts the gateway has loaded).
+- **Flow:** Probe gateway (3s connect timeout) → trigger scan → poll for completion (max 5s) → POST to `testing/run` → parse results → report summary to stderr
+- **Silent exit if:** Gateway unreachable, endpoint doesn't exist, commit failed, not in an Ignition project
 
 #### `scripts/run-ui-tests.sh` — Post-edit Playwright tests
 
@@ -223,7 +226,10 @@ Two new hook scripts in `scripts/`, plus the existing `ignition-lint.sh`:
 - **Detection:** Finds `e2e/` relative to project root (not hardcoded path)
 - **Scoping:** Extracts view area from path (`views/{Area}/...`) → maps to `e2e/tests/{area}/`
 - **Fallback:** If no matching test directory, runs `e2e/tests/smoke/`
-- **Silent exit if:** `e2e/node_modules` doesn't exist, `.auth/user.json` doesn't exist
+- **Concurrency guard:** Uses a lockfile (`e2e/.playwright-running.lock`) with `flock` to prevent concurrent Playwright runs. If another test run is in progress, the hook silently exits. The lockfile is removed on completion (or by trap on exit).
+- **Silent exit if:** `e2e/node_modules` doesn't exist, `.auth/user.json` doesn't exist, another test run is in progress, not a Perspective view.json
+
+**Performance note:** The self-gating check for `run-ui-tests.sh` is cheap — it reads `tool_input.file_path` from stdin, does a string match on `view.json`, checks two filesystem paths, and exits. This runs on every `Edit|Write` alongside `ignition-lint.sh`, but the early-exit path is ~5ms. The Playwright launch only happens for actual Perspective view edits.
 
 #### Self-gating design
 
@@ -296,6 +302,30 @@ claude-code-plugin/
 └── README.md                         # Updated with testing docs
 ```
 
+### Authentication Model
+
+Three auth contexts exist in this system, each appropriate for its use case:
+
+| Context | Auth method | Why |
+|---------|------------|-----|
+| **WebDev test endpoints** (`testing/run`, `testing/tags`) | No auth (`require-auth: false` in config.json) | These are developer-only endpoints on a local/dev gateway. They read/write tags and run scripts — capabilities that any authenticated Designer user already has. Requiring auth would add friction with no security benefit in dev. **Production gateways should never have these endpoints deployed.** |
+| **Gateway project scan** (triggered by hooks) | API token via `$IGNITION_API_TOKEN_FILE` | The scan endpoint is a custom WebDev endpoint that triggers Ignition's project resource reload. Token auth prevents accidental scans from unauthorized sources. Optional — hooks skip the scan if no token is configured. |
+| **Playwright e2e tests** | Username/password in `e2e/.env` | Playwright authenticates through the Perspective login form (same as a real user). Credentials are stored in `.env` (gitignored) and persisted to `.auth/user.json` by the auth setup fixture. |
+
+The `.env` file is gitignored by the scaffolded `e2e/.gitignore`. The auth state file `.auth/user.json` is also gitignored.
+
+### Version Control Guidance
+
+All scaffolded files should be committed to version control:
+- `ignition/script-python/testing/` — these are Ignition project resources, same as any other script module
+- `com.inductiveautomation.webdev/resources/testing/` — WebDev endpoints are project resources
+- `.ignition-stubs/testing/` — type stubs for IDE support
+- `e2e/` — test infrastructure (minus `node_modules/`, `test-results/`, `.auth/`, `.env`, which are in `.gitignore`)
+
+### Platform Support
+
+The plugin targets **macOS and Linux**. All scripts are bash. Windows users should use WSL, which is the standard recommendation for Claude Code on Windows. The detection and scaffolding scripts use POSIX-compatible utilities (`curl`, `jq`, `mkdir`, `cat`) that are available in all bash environments.
+
 ### What the Plugin Does NOT Scaffold
 
 Business-logic test modules. The framework gives you `testing.*` and the endpoints. Writing actual tests (`core.mes.changeover.__tests__/code.py`) is the developer's job — the plugin just makes it easy to get started.
@@ -313,8 +343,18 @@ The hook scripts can be tested by piping them mock JSON input (simulating Claude
 ## Migration Path for WHK-Global
 
 Once the plugin ships, WHK-Global can:
-1. Install the plugin
-2. Delete `.claude/hooks/ignition-lint.sh`, `run-tests.sh`, `run-ui-tests.sh` (plugin hooks replace them)
-3. Delete `.claude/commands/test.md` (plugin `/ignition-scada:test` replaces it)
-4. Keep project-specific test modules, page objects, and domain helpers (those aren't in the plugin)
-5. Keep `.claude/settings.json` hooks section can be cleaned up (plugin hooks handle it)
+
+1. Install the plugin (`claude plugin add`)
+2. Delete per-project hook scripts:
+   - `rm .claude/hooks/ignition-lint.sh` (replaced by plugin `scripts/ignition-lint.sh`)
+   - `rm .claude/hooks/run-tests.sh` (replaced by plugin `scripts/run-tests.sh`)
+   - `rm .claude/hooks/run-ui-tests.sh` (replaced by plugin `scripts/run-ui-tests.sh`)
+3. Delete per-project command:
+   - `rm .claude/commands/test.md` (replaced by plugin `/ignition-scada:test` skill)
+4. Clean up `.claude/settings.json` — remove the entire `hooks` section (plugin hooks handle it):
+   ```diff
+   - "hooks": { "PostToolUse": [...] }
+   ```
+5. Set environment variables (or add to `.env`):
+   - `IGNITION_API_TOKEN_FILE=~/whiskeyhouse/whk-services-deployments/secrets/IGNITION_API_TOKEN`
+6. Keep everything else — project-specific test modules (`core/mes/changeover/__tests__/`), page objects (`ChangeoverDashboard.ts`), domain API helpers (MES/WMS methods in `gateway-api.ts`), and the existing `testing/` framework files are all project-specific and remain unchanged

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -3,8 +3,8 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: 'ignition-nvim',
-  tagline: 'Neovim plugin for Ignition SCADA development',
+  title: 'Ignition Dev Tools',
+  tagline: 'Multi-editor IDE support for Ignition SCADA',
   favicon: 'img/favicon.ico',
 
   future: {
@@ -56,7 +56,7 @@ const config: Config = {
       respectPrefersColorScheme: false,
     },
     navbar: {
-      title: 'ignition-nvim',
+      title: 'Ignition Dev Tools',
       items: [
         {
           type: 'docSidebar',
@@ -91,6 +91,14 @@ const config: Config = {
           ],
         },
         {
+          title: 'Claude Code Plugin',
+          items: [
+            {label: 'Overview', to: '/docs/claude-code-plugin/overview'},
+            {label: 'Testing', to: '/docs/claude-code-plugin/testing'},
+            {label: 'Skills Reference', to: '/docs/claude-code-plugin/skills-reference'},
+          ],
+        },
+        {
           title: 'More',
           items: [
             {
@@ -113,7 +121,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['bash', 'json', 'yaml', 'python', 'lua'],
+      additionalLanguages: ['bash', 'json', 'yaml', 'python', 'lua', 'typescript'],
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -28,6 +28,15 @@ const sidebars: SidebarsConfig = {
         'configuration/options',
       ],
     },
+    {
+      type: 'category',
+      label: 'Claude Code Plugin',
+      items: [
+        'claude-code-plugin/overview',
+        'claude-code-plugin/testing',
+        'claude-code-plugin/skills-reference',
+      ],
+    },
     'credits',
   ],
 };


### PR DESCRIPTION
## Summary

- Add Jython gateway test framework scaffolding (`/ignition-scada:init-testing`)
- Add Playwright e2e test scaffolding (`/ignition-scada:init-e2e`)
- Add unified test runner skill (`/ignition-scada:test`)
- Add post-commit gateway test hook and post-edit Playwright hook
- All backed by deterministic shell scripts usable without Claude
- Bump plugin to v0.2.0

## New files

| File | Purpose |
|------|---------|
| `scripts/detect-project.sh` | Auto-detect Ignition project structure and gateway state |
| `scripts/scaffold-testing.sh` | Scaffold Jython framework + WebDev endpoints + stubs (1650 lines) |
| `scripts/scaffold-e2e.sh` | Scaffold Playwright setup with page objects and smoke tests (788 lines) |
| `scripts/run-tests.sh` | Post-commit hook: triggers gateway scan → runs Jython tests |
| `scripts/run-ui-tests.sh` | Post-edit hook: runs scoped Playwright tests on view.json changes |
| `skills/init-testing/SKILL.md` | Skill wrapping scaffold-testing.sh with auto-detection |
| `skills/init-e2e/SKILL.md` | Skill wrapping scaffold-e2e.sh with auto-detection |
| `skills/test/SKILL.md` | Unified test runner routing to gateway or Playwright |

## Design

Layered architecture: deterministic shell scripts do all file creation (heredocs), skills wrap them with auto-detection and user interaction, hooks self-gate and run tests automatically. Genericized from the working WHK-Global test infrastructure.

## Test plan

- [ ] Run `detect-project.sh` against a real Ignition project
- [ ] Run `scaffold-testing.sh` and `scaffold-e2e.sh` with `--dry-run`
- [ ] Run full scaffold against a test project
- [ ] Verify parameter substitutions (project name, tag provider)
- [ ] Verify hook self-gating (silent exit on non-matching input)
- [ ] Verify skill frontmatter is valid
- [ ] Test `/ignition-scada:init-testing` on a real Ignition project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin bumped to v0.2.0 with expanded testing capabilities
  * Added scaffolding and runnable workflows for gateway (Jython/WebDev) tests and Playwright E2E
  * New CLI commands: /ignition-scada:init-testing, /ignition-scada:init-e2e, /ignition-scada:test
  * Automated hooks to trigger gateway tests on commit and scoped UI tests on Perspective edits

* **Documentation**
  * README and multiple skill/design docs added or expanded with quick-starts, usage, and test-run guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->