### PR TITLE
fix(plugin): remove duplicate hooks reference from manifest

### DIFF
--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -10,6 +10,5 @@
   "repository": "https://github.com/whiskeyhouse/ignition-nvim",
   "license": "MIT",
   "keywords": ["ignition", "scada", "ics", "inductive-automation", "jython", "plc", "testing", "playwright"],
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
Claude Code auto-loads hooks/hooks.json by convention. Specifying it in plugin.json causes a "Duplicate hooks file detected" error on marketplace install.